### PR TITLE
[Refactor] 쿼리키 컨벤션 수정

### DIFF
--- a/blog/src/entities/series/model/index.ts
+++ b/blog/src/entities/series/model/index.ts
@@ -14,7 +14,7 @@ import { createBrowserSupabase } from "@/shared/model";
 import type { Database } from "@/shared/model/database.types";
 import { snakeToCamel } from "@/shared/util";
 
-export const seriesQueryKey = {
+export const SERIES_QUERY_KEY = {
   default: () => ["series"] as const
 } as const;
 
@@ -36,7 +36,7 @@ export const getSeries = async () => {
  */
 export const useGetAllSeries = () => {
   return useSuspenseQuery({
-    queryKey: seriesQueryKey.default(),
+    queryKey: SERIES_QUERY_KEY.default(),
     queryFn: getSeries
   });
 };
@@ -69,18 +69,15 @@ export const usePostAddNewSeries = () => {
     mutationFn: postAddNewSeries,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: seriesQueryKey.default()
+        queryKey: SERIES_QUERY_KEY.default()
       });
     }
   });
 };
 
-const SERIES_QUERY_KEY = {
-  default: ["series"]
-};
-
 export const getSeriesList = () => {
-  const queryKey = SERIES_QUERY_KEY.default;
+  const queryKey = SERIES_QUERY_KEY.default();
+
   const queryFn = async () => {
     const supabase = await createBrowserSupabase();
 

--- a/blog/src/entities/series/model/index.ts
+++ b/blog/src/entities/series/model/index.ts
@@ -15,7 +15,7 @@ import type { Database } from "@/shared/model/database.types";
 import { snakeToCamel } from "@/shared/util";
 
 export const seriesQueryKey = {
-  default: ["series"]
+  default: () => ["series"] as const
 } as const;
 
 export type Series = Database["public"]["Tables"]["series"]["Row"];
@@ -36,7 +36,7 @@ export const getSeries = async () => {
  */
 export const useGetAllSeries = () => {
   return useSuspenseQuery({
-    queryKey: seriesQueryKey.default,
+    queryKey: seriesQueryKey.default(),
     queryFn: getSeries
   });
 };
@@ -69,7 +69,7 @@ export const usePostAddNewSeries = () => {
     mutationFn: postAddNewSeries,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: seriesQueryKey.default
+        queryKey: seriesQueryKey.default()
       });
     }
   });

--- a/blog/src/entities/tag/model/index.ts
+++ b/blog/src/entities/tag/model/index.ts
@@ -14,8 +14,8 @@ import { createBrowserSupabase } from "@/shared/model";
 import type { Database } from "@/shared/model/database.types";
 
 export const tagQueryKey = {
-  default: ["tag"]
-} as const;
+  default: () => ["tags"] as const
+};
 
 export type Tag = Database["public"]["Tables"]["tags"]["Row"];
 
@@ -35,7 +35,7 @@ export const getTags = async () => {
  */
 export const useGetAllTags = () => {
   return useSuspenseQuery({
-    queryKey: tagQueryKey.default,
+    queryKey: tagQueryKey.default(),
     queryFn: getTags
   });
 };
@@ -68,7 +68,7 @@ export const usePostAddNewTag = () => {
     mutationFn: postAddNewTag,
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: tagQueryKey.default
+        queryKey: tagQueryKey.default()
       });
     }
   });


### PR DESCRIPTION
쿼리키를 다음과 같은 타입으로 관리한다.

```ts
export const ARTICLE_QUERY_KEY = {
  default: (status: ArticleStatus) => ["article", status] as const,

  list_all: (status: ArticleStatus) =>
    [...ARTICLE_QUERY_KEY.default(status), "all"] as const,
  list_series: (status: ArticleStatus, seriesName: string) =>
    [...ARTICLE_QUERY_KEY.default(status), seriesName] as const
};
```

key  ,value 값을 함수로 관리하는 이유는 객체 내부에서 정의된 함수가 객체를 참조할 수 있게 하기 위함이다. 