### PR TITLE
[Refactor] RouteHandler 의 Response 타입 획일화 

### DIFF
--- a/blog/app/api/articles/images/route.ts
+++ b/blog/app/api/articles/images/route.ts
@@ -6,7 +6,11 @@ import type {
 } from "@/entities/article/model";
 
 import { createServerSupabase } from "@/shared/model";
-import { attachIamgeUrl, createImageConfig } from "@/shared/route";
+import {
+  attachIamgeUrl,
+  createImageConfig,
+  createStorageErrorResponse
+} from "@/shared/route";
 
 const ARTICLE_IMAGE_STORAGE_NAME = "article_image";
 
@@ -45,16 +49,7 @@ export const POST = async (req: NextRequest) => {
   const errorResponse = responseArray.find((response) => !!response.error);
 
   if (errorResponse) {
-    return NextResponse.json(
-      {
-        code: 500,
-        message: errorResponse.error.message
-      },
-      {
-        status: 500,
-        statusText: errorResponse.error.message
-      }
-    );
+    return NextResponse.json(createStorageErrorResponse(errorResponse.error));
   }
 
   const successResponses = responseArray.filter((response) => !!response.data);

--- a/blog/app/api/articles/images/route.ts
+++ b/blog/app/api/articles/images/route.ts
@@ -45,10 +45,16 @@ export const POST = async (req: NextRequest) => {
   const errorResponse = responseArray.find((response) => !!response.error);
 
   if (errorResponse) {
-    return NextResponse.json({
-      code: 500,
-      message: errorResponse.error.message
-    });
+    return NextResponse.json(
+      {
+        code: 500,
+        message: errorResponse.error.message
+      },
+      {
+        status: 500,
+        statusText: errorResponse.error.message
+      }
+    );
   }
 
   const successResponses = responseArray.filter((response) => !!response.data);

--- a/blog/app/api/articles/images/route.ts
+++ b/blog/app/api/articles/images/route.ts
@@ -42,18 +42,20 @@ export const POST = async (req: NextRequest) => {
     images.map((file) => uploadImageAction({ file, articleId }))
   );
 
-  const uploadedImages = responseArray.filter((response) => !response.error);
+  const errorResponse = responseArray.find((response) => !!response.error);
 
-  if (uploadedImages.length < responseArray.length) {
+  if (errorResponse) {
     return NextResponse.json({
-      status: 500,
-      message: "이미지 업로드에 실패했습니다."
+      code: 500,
+      message: errorResponse.error.message
     });
   }
 
+  const successResponses = responseArray.filter((response) => !!response.data);
+
   return NextResponse.json<PostArticleImageResponse>({
-    status: 200,
+    code: 200,
     message: "이미지 업로드에 성공했습니다.",
-    data: uploadedImages.map(({ data }) => attachIamgeUrl(data))
+    data: successResponses.map(({ data }) => attachIamgeUrl(data))
   });
 };

--- a/blog/app/api/articles/thumbnails/route.ts
+++ b/blog/app/api/articles/thumbnails/route.ts
@@ -32,13 +32,19 @@ export const POST = async (req: NextRequest) => {
   const response = await uploadThumbnail({ file, articleId });
 
   if (response.error) {
-    return NextResponse.json({
-      status: 500,
-      message: "이미지 업로드에 실패했습니다."
-    });
+    return NextResponse.json(
+      {
+        code: 500,
+        message: response.error.message
+      },
+      {
+        status: 500,
+        statusText: response.error.message
+      }
+    );
   }
   return NextResponse.json<PostArticleThumbnailResponse>({
-    status: 200,
+    code: 200,
     message: "이미지 업로드에 성공했습니다.",
     data: attachIamgeUrl(response.data)
   });

--- a/blog/app/api/articles/thumbnails/route.ts
+++ b/blog/app/api/articles/thumbnails/route.ts
@@ -6,7 +6,11 @@ import type {
 } from "@/entities/article/model";
 
 import { createServerSupabase } from "@/shared/model";
-import { attachIamgeUrl, createImageConfig } from "@/shared/route";
+import {
+  attachIamgeUrl,
+  createImageConfig,
+  createStorageErrorResponse
+} from "@/shared/route";
 
 const uploadThumbnail = async ({
   file,
@@ -32,17 +36,9 @@ export const POST = async (req: NextRequest) => {
   const response = await uploadThumbnail({ file, articleId });
 
   if (response.error) {
-    return NextResponse.json(
-      {
-        code: 500,
-        message: response.error.message
-      },
-      {
-        status: 500,
-        statusText: response.error.message
-      }
-    );
+    return NextResponse.json(createStorageErrorResponse(response.error));
   }
+
   return NextResponse.json<PostArticleThumbnailResponse>({
     code: 200,
     message: "이미지 업로드에 성공했습니다.",

--- a/blog/src/entities/article/model/index.ts
+++ b/blog/src/entities/article/model/index.ts
@@ -28,7 +28,7 @@ export interface PostArticleImageRequest {
 }
 
 export interface PostArticleImageResponse {
-  status: number;
+  code: number;
   message: string;
   data: {
     path: string;
@@ -56,10 +56,9 @@ export const postArticleImage = async ({
     body: form
   });
 
-  const { status, data, message } =
-    (await response.json()) as PostArticleImageResponse;
+  const { data, message } = (await response.json()) as PostArticleImageResponse;
 
-  if (status > 200) {
+  if (!response.ok) {
     throw new Error(message);
   }
 

--- a/blog/src/entities/article/model/index.ts
+++ b/blog/src/entities/article/model/index.ts
@@ -71,7 +71,7 @@ export interface PostArticleThumbnailRequest {
 }
 
 export interface PostArticleThumbnailResponse {
-  status: number;
+  code: number;
   message: string;
   data: {
     path: string;
@@ -99,10 +99,10 @@ const postArticleThumbnail = () => {
       body: formData
     });
 
-    const { status, data, message } =
+    const { data, message } =
       (await response.json()) as PostArticleThumbnailResponse;
 
-    if (status > 200) {
+    if (!response.ok) {
       throw new Error(message);
     }
 

--- a/blog/src/shared/route/createStorageErrorResponse.ts
+++ b/blog/src/shared/route/createStorageErrorResponse.ts
@@ -1,0 +1,8 @@
+import type { StorageError } from "@supabase/storage-js";
+
+export const createStorageErrorResponse = (error: StorageError) => {
+  const body = { code: 500, message: error.message };
+  const init = { status: 500, statusText: error.message };
+
+  return [body, init] as const;
+};

--- a/blog/src/shared/route/index.ts
+++ b/blog/src/shared/route/index.ts
@@ -3,3 +3,4 @@ export * from "./camelToSnake";
 export * from "./createPostgressErrorResponse";
 export * from "./createImageConfig";
 export * from "./attachIamgeUrl";
+export * from "./createStorageErrorResponse";


### PR DESCRIPTION
## 아티클 이미지 및 썸네일 업로드 프로세스 개선

이 풀 리퀘스트는 아티클 이미지 및 썸네일 업로드 프로세스의 오류 처리 및 응답 구조를 개선하기 위한 여러 변경 사항을 포함합니다. 주요 변경 사항으로는 스토리지 오류 응답을 생성하는 새로운 유틸리티 함수 추가, 이미지 및 썸네일 업로드에 대한 응답 구조 업데이트, 애플리케이션 전체에서 일관된 오류 처리 보장이 있습니다.

### 오류 처리 개선:

* [`blog/src/shared/route/createStorageErrorResponse.ts`](diffhunk://#diff-345bd7c0513cbc9ed0375cb50c5412a7044c44554db6f85b677248e42afe5e8aR1-R8): 스토리지 오류 응답을 표준화하는 새로운 유틸리티 함수 `createStorageErrorResponse`를 추가했습니다.
* [`blog/app/api/articles/images/route.ts`](diffhunk://#diff-ece697b651fca1d0e59597d75592f50334ef52ac134a4ced19d78392cb8a92ecL45-R60): 오류 처리를 위해 새로운 `createStorageErrorResponse` 함수를 사용하도록 이미지 업로드 엔드포인트를 업데이트했습니다.
* [`blog/app/api/articles/thumbnails/route.ts`](diffhunk://#diff-b5433025d34e5fce3443456852f6fab6aab711fab9a7fe18226e7bb049284cccL35-R43): 오류 처리를 위해 새로운 `createStorageErrorResponse` 함수를 사용하도록 썸네일 업로드 엔드포인트를 업데이트했습니다.

### 응답 구조 업데이트:

* [`blog/src/entities/article/model/index.ts`](diffhunk://#diff-eaa88ce95a0d76fb1435c60298eafee02814c8283f4ec2496708911b18f69930L31-R31): 응답 코드에 `status` 대신 `code`를 사용하도록 `PostArticleImageResponse` 및 `PostArticleThumbnailResponse` 인터페이스를 변경하고 이 변경 사항을 반영하도록 관련 함수를 업데이트했습니다. [[1]](diffhunk://#diff-eaa88ce95a0d76fb1435c60298eafee02814c8283f4ec2496708911b18f69930L31-R31) [[2]](diffhunk://#diff-eaa88ce95a0d76fb1435c60298eafee02814c8283f4ec2496708911b18f69930L75-R74)

### 가져오기 조정:

* [`blog/app/api/articles/images/route.ts`](diffhunk://#diff-ece697b651fca1d0e59597d75592f50334ef52ac134a4ced19d78392cb8a92ecL9-R13): `createStorageErrorResponse` 함수에 대한 가져오기를 추가했습니다.
* [`blog/app/api/articles/thumbnails/route.ts`](diffhunk://#diff-b5433025d34e5fce3443456852f6fab6aab711fab9a7fe18226e7bb049284cccL9-R13): `createStorageErrorResponse` 함수에 대한 가져오기를 추가했습니다.
* [`blog/src/shared/route/index.ts`](diffhunk://#diff-f4f4b66018f12cfe09ff2672a3be3bedc2bccfd9bf08d84e9f8a9a4a77dbc4c1R6): 새로운 `createStorageErrorResponse` 함수를 내보냈습니다.
---

모든 api 요청의 response 타입을 다음과 같이 수정합니다. 

```tsx
{
  code : number;
  messag : string;
  data ?: unknow
}

