### PR TITLE
[Feat] /article/[articleId] 에서 작용 할 사이드바 컴포넌트 생성 

### DIFF
--- a/blog/app/article/[articleId]/article.styles.css
+++ b/blog/app/article/[articleId]/article.styles.css
@@ -67,7 +67,7 @@
 .unordered-list,
 .ordered-list {
   padding-left: 2rem;
-  margin-bottom: 1rem;
+  margin: 1rem 0;
 }
 
 .unordered-list {

--- a/blog/app/article/[articleId]/page.tsx
+++ b/blog/app/article/[articleId]/page.tsx
@@ -1,5 +1,11 @@
 import "./article.styles.css";
 
+import {
+  createNestedHeadings,
+  parsingHeading
+} from "@/features/article/lib/createNestedHeadings";
+import { ArticleSidebar } from "@/features/article/ui/ArticleSidebar";
+
 import { rehypeMarkdown } from "@/entities/article/lib";
 import { getArticleById } from "@/entities/article/model";
 import { TagChip } from "@/entities/tag/ui";
@@ -59,7 +65,12 @@ const ArticlePage: React.FC<ArticlePageProps> = async ({ params }) => {
           className="w-full pb-32 lg:flex-grow"
         />
         {/* 사이드바 */}
-        {/* <aside className="hidden lg:block"></aside> */}
+        <aside className="hidden lg:block">
+          <ArticleSidebar
+            articleId={articleId}
+            headings={createNestedHeadings(parsingHeading(content))}
+          />
+        </aside>
       </section>
     </section>
   );

--- a/blog/app/article/[articleId]/page.tsx
+++ b/blog/app/article/[articleId]/page.tsx
@@ -58,18 +58,20 @@ const ArticlePage: React.FC<ArticlePageProps> = async ({ params }) => {
         </div>
       </header>
 
-      <section className="media-padding-x flex min-h-screen">
+      <section className="media-padding-x flex min-h-screen gap-2">
         {/* 본문 */}
         <article
           dangerouslySetInnerHTML={{ __html: html }}
           className="w-full pb-32 lg:flex-grow"
         />
         {/* 사이드바 */}
-        <aside className="hidden lg:block">
-          <ArticleSidebar
-            articleId={articleId}
-            headings={createNestedHeadings(parsingHeading(content))}
-          />
+        <aside className="relative hidden text-gray-400 xl:block">
+          <div className="sticky top-32">
+            <ArticleSidebar
+              articleId={articleId}
+              headings={createNestedHeadings(parsingHeading(content))}
+            />
+          </div>
         </aside>
       </section>
     </section>

--- a/blog/package-lock.json
+++ b/blog/package-lock.json
@@ -18,6 +18,7 @@
         "rehype-add-classes": "^1.0.0",
         "rehype-pretty-code": "^0.14.0",
         "rehype-react": "^8.0.0",
+        "rehype-slug": "^6.0.0",
         "rehype-stringify": "^10.0.1",
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.1",
@@ -9421,6 +9422,11 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-slugger": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -9685,6 +9691,18 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hast-util-has-property/-/hast-util-has-property-1.0.4.tgz",
       "integrity": "sha512-ghHup2voGfgFoHMGnaLHOjbYFACKrRh9KFttdCzMCbFoBMJXiNi2+XTrPP8+q6cDJM/RSqlCfVWrjp1H201rZg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -14783,6 +14801,22 @@
         "@types/hast": "^3.0.0",
         "hast-util-to-jsx-runtime": "^2.0.0",
         "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/blog/package.json
+++ b/blog/package.json
@@ -23,6 +23,7 @@
     "rehype-add-classes": "^1.0.0",
     "rehype-pretty-code": "^0.14.0",
     "rehype-react": "^8.0.0",
+    "rehype-slug": "^6.0.0",
     "rehype-stringify": "^10.0.1",
     "remark-parse": "^11.0.0",
     "remark-rehype": "^11.1.1",

--- a/blog/src/entities/article/lib/rehypeMarkdown.ts
+++ b/blog/src/entities/article/lib/rehypeMarkdown.ts
@@ -1,5 +1,6 @@
 import rehypeAddClasses from "rehype-add-classes";
 import rehypePrettyCode from "rehype-pretty-code";
+import rehypeSlug from "rehype-slug";
 import rehypeStringfy from "rehype-stringify";
 import remarkParse from "remark-parse";
 import remark2rehype from "remark-rehype";
@@ -12,6 +13,8 @@ export const rehypeMarkdown = async (markdown: string) => {
     // AST 형태로 파싱된 마크다운 텍스트를 HTML로 변환 합니다.
     .use(remark2rehype)
     // HTML로 변환된 AST를 문자열로 변환 합니다.
+    .use(rehypeSlug)
+    // 각 Heading 태그에 id 를 추가 합니다.
     .use(rehypeAddClasses, {
       h1: "heading-1",
       h2: "heading-2",

--- a/blog/src/features/article/lib/createNestedHeadings.test.ts
+++ b/blog/src/features/article/lib/createNestedHeadings.test.ts
@@ -1,0 +1,120 @@
+import {
+  type HeadingInfo,
+  type NestedHeadingList,
+  createNestedHeadings,
+  parsingHeading
+} from "./createNestedHeadings";
+
+describe("parsingHeading", () => {
+  test("heading 이 존재하지 않는 경우 빈 배열을 반환한다.", () => {
+    const markdown = `마크다운 
+    마크다운 테스트 
+    마크다운`;
+
+    const expected: HeadingInfo[] = [];
+
+    const result = parsingHeading(markdown);
+    expect(result).toEqual(expected);
+  });
+
+  test("heading 이 존재하는 경우 정상적으로 파싱한다.", () => {
+    const markdown = `
+# heading1
+## heading2
+### heading3
+    
+마크다운 테스트
+    `;
+
+    const expected = [
+      { level: 1, title: "heading1" },
+      { level: 2, title: "heading2" },
+      { level: 3, title: "heading3" }
+    ];
+
+    const result = parsingHeading(markdown);
+    expect(result).toEqual(expected);
+  });
+});
+
+describe("createNestedHeadings", () => {
+  test("빈 배열이 들어온 경우 빈 배열을 반환한다.", () => {
+    const headings: HeadingInfo[] = [];
+    const expected: NestedHeadingList = [];
+
+    const result = createNestedHeadings(headings);
+    expect(result).toEqual(expected);
+  });
+
+  test("올바른 Headings 가 들어왔을 때 계층적인 배열을 반환한다.", () => {
+    const headings: HeadingInfo[] = [
+      { level: 1, title: "heading1" },
+      { level: 2, title: "heading2" },
+      { level: 3, title: "heading3" },
+      { level: 3, title: "heading4" },
+      { level: 2, title: "heading5" },
+      { level: 1, title: "heading6" }
+    ];
+
+    const expected: NestedHeadingList = [
+      "heading1",
+      ["heading2", ["heading3", "heading4"], "heading5"],
+      "heading6"
+    ];
+
+    const result = createNestedHeadings(headings);
+    expect(result).toEqual(expected);
+  });
+
+  test("단일 레벨의 Headings 가 들어왔을 때 올바르게 반환한다.", () => {
+    const headings: HeadingInfo[] = [
+      { level: 1, title: "heading1" },
+      { level: 1, title: "heading2" },
+      { level: 1, title: "heading3" }
+    ];
+
+    const expected: NestedHeadingList = ["heading1", "heading2", "heading3"];
+
+    const result = createNestedHeadings(headings);
+    expect(result).toEqual(expected);
+  });
+
+  test("다양한 레벨의 Headings 가 들어왔을 때 올바르게 계층 구조를 반환한다.", () => {
+    const headings: HeadingInfo[] = [
+      { level: 1, title: "heading1" },
+      { level: 2, title: "heading2" },
+      { level: 3, title: "heading3" },
+      { level: 2, title: "heading4" },
+      { level: 1, title: "heading5" },
+      { level: 2, title: "heading6" }
+    ];
+
+    const expected: NestedHeadingList = [
+      "heading1",
+      ["heading2", ["heading3"], "heading4"],
+      "heading5",
+      ["heading6"]
+    ];
+
+    const result = createNestedHeadings(headings);
+    expect(result).toEqual(expected);
+  });
+
+  test("중첩된 레벨의 Headings 가 들어왔을 때 올바르게 계층 구조를 반환한다.", () => {
+    const headings: HeadingInfo[] = [
+      { level: 1, title: "heading1" },
+      { level: 2, title: "heading2" },
+      { level: 3, title: "heading3" },
+      { level: 4, title: "heading4" },
+      { level: 5, title: "heading5" }
+    ];
+
+    const expected: NestedHeadingList = [
+      "heading1",
+      ["heading2", ["heading3", ["heading4", ["heading5"]]]]
+    ];
+
+    const result = createNestedHeadings(headings);
+    expect(result).toEqual(expected);
+  });
+});

--- a/blog/src/features/article/lib/createNestedHeadings.ts
+++ b/blog/src/features/article/lib/createNestedHeadings.ts
@@ -1,0 +1,53 @@
+export interface HeadingInfo {
+  level: number;
+  title: string;
+}
+
+export const parsingHeading = (markdown: string): HeadingInfo[] => {
+  return markdown
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^#{1,3}\s/.test(line)) // '#' 문자가 1개 이상 3개 이하로 반복되고, 그 뒤에 공백이 있는 경우에만 필터링
+    .map((line) => {
+      const level = line.match(/^#+/)?.[0].length || 1; // '#'의 개수를 레벨로 설정
+      const title = line.replace(/^#+\s*/, "").trim(); // '#'과 공백을 제거한 제목
+      return { level, title };
+    });
+};
+
+export type NestedHeadingList = (string | string[] | NestedHeadingList)[];
+
+type CreateNestedHeadings = (
+  headings: HeadingInfo[],
+  level?: number
+) => NestedHeadingList;
+
+export const createNestedHeadings: CreateNestedHeadings = (
+  headings,
+  level = 1
+) => {
+  const currentLevelHeadings: NestedHeadingList = [];
+
+  if (headings.length === 0) {
+    return currentLevelHeadings;
+  }
+
+  while (headings.length > 0) {
+    const heading = headings.shift()!;
+
+    if (heading.level === level) {
+      currentLevelHeadings.push(heading.title);
+      continue;
+    }
+
+    if (heading.level < level) {
+      headings.unshift(heading);
+      return currentLevelHeadings;
+    }
+
+    headings.unshift(heading);
+    currentLevelHeadings.push(createNestedHeadings(headings, level + 1));
+  }
+
+  return currentLevelHeadings;
+};

--- a/blog/src/features/article/lib/index.ts
+++ b/blog/src/features/article/lib/index.ts
@@ -1,1 +1,2 @@
 export * from "./useMarkdown";
+export * from "./useArticleSidebar";

--- a/blog/src/features/article/lib/useArticleSidebar.ts
+++ b/blog/src/features/article/lib/useArticleSidebar.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+
+export const useArticleSidebar = () => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const transformIdToSlug = (id: string) => {
+    return id
+      .replace(/\s+/g, "-")
+      .replace(/[^\w\s가-힣-]/g, "")
+      .toLowerCase();
+  };
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            setActiveId(transformIdToSlug(entry.target.id));
+          }
+        });
+      },
+
+      { rootMargin: "0% 0% -80% 0%" }
+    );
+    const headings = document.querySelectorAll("h1, h2, h3");
+
+    console.log(headings);
+    headings.forEach((heading) => observer.observe(heading));
+
+    return () => {
+      headings.forEach((heading) => observer.unobserve(heading));
+    };
+  }, []);
+
+  const handleHeadingScroll = (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    headingId: string
+  ) => {
+    event.preventDefault();
+    const element = document.getElementById(headingId);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
+  return { activeId, handleHeadingScroll, transformIdToSlug };
+};

--- a/blog/src/features/article/ui/ArticleSidebar.stories.tsx
+++ b/blog/src/features/article/ui/ArticleSidebar.stories.tsx
@@ -1,3 +1,7 @@
+import {
+  createNestedHeadings,
+  parsingHeading
+} from "../lib/createNestedHeadings";
 import { ArticleSidebar } from "./ArticleSidebar";
 import { Meta, StoryObj } from "@storybook/react";
 import React from "react";
@@ -59,14 +63,18 @@ type Story = StoryObj<typeof ArticleSidebar>;
 
 export const Default: Story = {
   args: {
-    headings: [
-      "Heading 1",
-      "Heading 2",
-      ["Heading 2.1", ["Heading 2.1.1", "Heading 2.1.2"]],
-      ["Heading 2.2", ["Heading 2.2.1", ["Heading 2.2.1.1"], "Heading 2.2.2"]],
-      "Heading 3"
-    ],
-    depth: 1
+    headings: createNestedHeadings(
+      parsingHeading(`
+# Heading 1
+## Heading 2
+### Heading 3
+# Heading 4
+# Heading 5
+## Heading 6
+## Heading 7
+###Heading 8
+ `)
+    )
   },
   render: (args) => (
     <div className="p-4">

--- a/blog/src/features/article/ui/ArticleSidebar.stories.tsx
+++ b/blog/src/features/article/ui/ArticleSidebar.stories.tsx
@@ -1,0 +1,76 @@
+import { ArticleSidebar } from "./ArticleSidebar";
+import { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
+const meta: Meta<typeof ArticleSidebar> = {
+  title: "features/article/ArticleSidebar",
+  component: ArticleSidebar,
+  argTypes: {
+    headings: {
+      control: {
+        type: "object"
+      },
+      description: "계층적인 헤딩 배열"
+    },
+    depth: {
+      control: {
+        type: "number"
+      },
+      description: "현재 깊이"
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `
+## 개요
+\`ArticleSidebar\` 컴포넌트는 계층적인 헤딩 구조를 나타내는 사이드바 컴포넌트입니다.
+
+## Props
+
+### ArticleSidebarProps
+- \`headings\` (string[] | (string | Headings)[]): 계층적인 헤딩 배열.
+- \`depth\` (number): 현재 깊이.
+
+## 사용 예시
+
+\`\`\`typescript
+import { ArticleSidebar } from "@/features/article/ui/ArticleSidebar";
+
+const ExampleComponent = () => {
+  const headings = [
+    "Introduction",
+    ["Chapter 1", ["Section 1.1", ["Subsection 1.1.1", "Subsection 1.1.2"]]],
+    ["Chapter 2", ["Section 2.1", "Section 2.2"]],
+    "Conclusion",
+  ];
+
+  return <ArticleSidebar headings={headings} />;
+};
+\`\`\`
+        `
+      }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof ArticleSidebar>;
+
+export const Default: Story = {
+  args: {
+    headings: [
+      "Heading 1",
+      "Heading 2",
+      ["Heading 2.1", ["Heading 2.1.1", "Heading 2.1.2"]],
+      ["Heading 2.2", ["Heading 2.2.1", ["Heading 2.2.1.1"], "Heading 2.2.2"]],
+      "Heading 3"
+    ],
+    depth: 1
+  },
+  render: (args) => (
+    <div className="p-4">
+      <ArticleSidebar {...args} />
+    </div>
+  )
+};

--- a/blog/src/features/article/ui/ArticleSidebar.tsx
+++ b/blog/src/features/article/ui/ArticleSidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useArticleSidebar } from "../lib";
 import Link from "next/link";
 import React from "react";
 
@@ -16,16 +17,8 @@ export const ArticleSidebar: React.FC<ArticleSidebarProps> = ({
   headings,
   depth = 1
 }) => {
-  const handleClick = (
-    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
-    headingId: string
-  ) => {
-    event.preventDefault();
-    const element = document.getElementById(headingId);
-    if (element) {
-      element.scrollIntoView({ behavior: "smooth" });
-    }
-  };
+  const { activeId, handleHeadingScroll, transformIdToSlug } =
+    useArticleSidebar();
 
   return (
     <ul className="pl-2">
@@ -41,17 +34,18 @@ export const ArticleSidebar: React.FC<ArticleSidebarProps> = ({
           );
         }
 
-        // rehype-slug 는  모든 특수문자를 제거하고 공백을 -로 변환하여 id 를 생성한다.
-        // 이에 따라 특수문자를 제외한 모든 문자를 제거하고 공백을 -로 변환하여 id를 생성한다.
-        const headingId = heading
-          .replace(/\s+/g, "-")
-          .replace(/[^\w\s가-힣-]/g, "");
+        const headingId = transformIdToSlug(heading);
 
         return (
           <li key={`${depth}-${index}-li`}>
             <Link
               href={`/article/${articleId}#${headingId}`}
-              onClick={(event) => handleClick(event, headingId)}
+              className={`transition-all duration-200 ${
+                activeId === headingId
+                  ? "font-bold text-blue-600"
+                  : "text-gray-500"
+              }`}
+              onClick={(event) => handleHeadingScroll(event, headingId)}
             >
               {heading}
             </Link>

--- a/blog/src/features/article/ui/ArticleSidebar.tsx
+++ b/blog/src/features/article/ui/ArticleSidebar.tsx
@@ -37,7 +37,7 @@ export const ArticleSidebar: React.FC<ArticleSidebarProps> = ({
         const headingId = transformIdToSlug(heading);
 
         return (
-          <li key={`${depth}-${index}-li`}>
+          <li className="my-2" key={`${depth}-${index}-li`}>
             <Link
               href={`/article/${articleId}#${headingId}`}
               className={`transition-all duration-200 ${

--- a/blog/src/features/article/ui/ArticleSidebar.tsx
+++ b/blog/src/features/article/ui/ArticleSidebar.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+type Heading = string | Heading[];
+
+interface ArticleSidebarProps {
+  headings: Heading[];
+  depth?: number;
+}
+
+export const ArticleSidebar: React.FC<ArticleSidebarProps> = ({
+  headings,
+  depth = 1
+}) => {
+  return (
+    <ul className="pl-2">
+      {headings.map((heading, index) => {
+        if (Array.isArray(heading)) {
+          return (
+            <ArticleSidebar
+              headings={heading}
+              depth={depth + 1}
+              key={`${depth}-${index}-ul`}
+            />
+          );
+        }
+        return <li key={`${depth}-${index}-li`}>{heading}</li>;
+      })}
+    </ul>
+  );
+};

--- a/blog/src/features/article/ui/ArticleSidebar.tsx
+++ b/blog/src/features/article/ui/ArticleSidebar.tsx
@@ -1,29 +1,62 @@
+"use client";
+
+import Link from "next/link";
 import React from "react";
 
 type Heading = string | Heading[];
 
 interface ArticleSidebarProps {
+  articleId: string;
   headings: Heading[];
   depth?: number;
 }
 
 export const ArticleSidebar: React.FC<ArticleSidebarProps> = ({
+  articleId,
   headings,
   depth = 1
 }) => {
+  const handleClick = (
+    event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
+    headingId: string
+  ) => {
+    event.preventDefault();
+    const element = document.getElementById(headingId);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth" });
+    }
+  };
+
   return (
     <ul className="pl-2">
       {headings.map((heading, index) => {
         if (Array.isArray(heading)) {
           return (
             <ArticleSidebar
+              articleId={articleId}
               headings={heading}
               depth={depth + 1}
               key={`${depth}-${index}-ul`}
             />
           );
         }
-        return <li key={`${depth}-${index}-li`}>{heading}</li>;
+
+        // rehype-slug 는  모든 특수문자를 제거하고 공백을 -로 변환하여 id 를 생성한다.
+        // 이에 따라 특수문자를 제외한 모든 문자를 제거하고 공백을 -로 변환하여 id를 생성한다.
+        const headingId = heading
+          .replace(/\s+/g, "-")
+          .replace(/[^\w\s가-힣-]/g, "");
+
+        return (
+          <li key={`${depth}-${index}-li`}>
+            <Link
+              href={`/article/${articleId}#${headingId}`}
+              onClick={(event) => handleClick(event, headingId)}
+            >
+              {heading}
+            </Link>
+          </li>
+        );
       })}
     </ul>
   );


### PR DESCRIPTION
## 블로그 게시글 페이지 기능 개선 (Pull Request 요약)

이 Pull Request는 블로그 게시글 페이지 기능을 향상시키기 위한 여러 변경 사항을 포함하며, 중첩된 제목을 가진 사이드바 추가 및 마크다운 처리 개선 등이 포함됩니다. 주요 변경 사항으로는 목록에 대한 CSS 업데이트, 새로운 유틸리티 및 컴포넌트 가져오기, 게시글 페이지에 사이드바 추가, 종속성 업데이트 등이 있습니다.

### 게시글 페이지 개선 사항:

* `blog/app/article/[articleId]/page.tsx`: 게시글 사이드바에 중첩된 제목을 생성하고 표시하기 위해 `ArticleSidebar` 컴포넌트와 `createNestedHeadings` 및 `parsingHeading` 유틸리티를 추가했습니다. ([blog/app/article/[articleId]/page.tsxR3-R8](diffhunk://#diff-dbf88431f7aee9b1a56783ea34cb3220b852074065713dce9f69884559253c0fR3-R8), [blog/app/article/[articleId]/page.tsxL55-R75](diffhunk://#diff-dbf88431f7aee9b1a56783ea34cb3220b852074065713dce9f69884559253c0fL55-R75))

### CSS 업데이트:

* `blog/app/article/[articleId]/article.styles.css`: `.unordered-list` 및 `.ordered-list` 클래스의 마진을 하단 마진뿐만 아니라 `1rem 0`으로 수정했습니다. ([blog/app/article/[articleId]/article.styles.cssL70-R70](diffhunk://#diff-608d38ce694f77cbc44277d96a109fd3108ce3bdf0cf246b7d302f36d7d736a5L70-R70))

### 종속성 업데이트:

* `blog/package-lock.json` 및 `blog/package.json`: 슬러그 생성 및 제목 처리를 지원하기 위해 새로운 종속성 `rehype-slug`, `github-slugger` 및 `hast-util-heading-rank`를 추가했습니다. [[1]](diffhunk://#diff-640f6c187ddf3e6ff74472e8be547d1a65de5fabb79e8e547f2116c0a2fb4d75R21) [[2]](diffhunk://#diff-640f6c187ddf3e6ff74472e8be547d1a65de5fabb79e8e547f2116c0a2fb4d75R9425-R9429) [[3]](diffhunk://#diff-640f6c187ddf3e6ff74472e8be547d1a65de5fabb79e8e547f2116c0a2fb4d75R9699-R9710) [[4]](diffhunk://#diff-640f6c187ddf3e6ff74472e8be547d1a65de5fabb79e8e547f2116c0a2fb4d75R14810-R14825) [[5]](diffhunk://#diff-4bab3c7f9c54a7566dabad9d0701fa289bde5cc3360227ce37ce94e866f3eee7R26)

### 마크다운 처리 개선 사항:

* [`blog/src/entities/article/lib/rehypeMarkdown.ts`](diffhunk://#diff-ecfea0075b8236f5344a3892d3441e3fd596dc3cdfe30416e8254246d52b31f7R3): `rehypeSlug`를 가져와서 제목에 ID를 추가하기 위해 `rehypeMarkdown` 함수를 업데이트했습니다. [[1]](diffhunk://#diff-ecfea0075b8236f5344a3892d3441e3fd596dc3cdfe30416e8254246d52b31f7R3) [[2]](diffhunk://#diff-ecfea0075b8236f5344a3892d3441e3fd596dc3cdfe30416e8254246d52b31f7R16-R17)

### 새로운 유틸리티 및 컴포넌트:

* [`blog/src/features/article/lib/createNestedHeadings.ts`](diffhunk://#diff-65d4d1e632169573702c1c0e4c73d67984f3f7dfff3034d7cc8ae29baedb8148R1-R53): 마크다운 제목을 구문 분석하고 중첩된 제목 구조를 생성하는 `parsingHeading` 및 `createNestedHeadings` 함수를 추가했습니다.
* [`blog/src/features/article/ui/ArticleSidebar.tsx`](diffhunk://#diff-6677defd07bcb99fb6eb11e812f9ba7002485cb7fef125ce65d2db0bc5190bd8R1-R57): 중첩된 제목을 사이드바에 표시하는 `ArticleSidebar` 컴포넌트를 추가했습니다.
* [`blog/src/features/article/lib/useArticleSidebar.ts`](diffhunk://#diff-63632e011d710c90849b297b016a13041432c3eb4a396bf030bd7e36102c2f35R1-R47): 활성 제목을 관리하고 제목으로 스크롤하는 기능을 처리하는 `useArticleSidebar` 훅을 추가했습니다.
* [`blog/src/features/article/lib/createNestedHeadings.test.ts`](diffhunk://#diff-68edaef0c76f64f1821af93b659d5b303586cb7508f4e697ec66ba6ba0a9d1ccR1-R120): 제목의 올바른 구문 분석 및 중첩을 보장하기 위해 `parsingHeading` 및 `createNestedHeadings` 함수에 대한 테스트를 추가했습니다.

