### PR TITLE
 [Fix] 글 쓰기 페이지에선 status 와 상관 없이 모든 데이터를 가져오도록 수정

### DIFF
--- a/blog/app/article/[articleId]/page.tsx
+++ b/blog/app/article/[articleId]/page.tsx
@@ -9,7 +9,7 @@ interface ArticlePageProps {
 
 const ArticlePage: React.FC<ArticlePageProps> = async ({ params }) => {
   const { articleId } = await params;
-  const articleData = await getArticleById(articleId);
+  const articleData = await getArticleById(articleId, "published");
 
   const {
     data: { user }

--- a/blog/app/temp/page.tsx
+++ b/blog/app/temp/page.tsx
@@ -1,6 +1,6 @@
 import { HydrationBoundary } from "@tanstack/react-query";
 
-import { TempArticleListView } from "@/views/article/ui/TempArticleListView";
+import { TempArticleListView } from "@/views/article/ui";
 
 import {
   getArticleList,

--- a/blog/app/write/[articleId]/page.tsx
+++ b/blog/app/write/[articleId]/page.tsx
@@ -11,7 +11,7 @@ interface ArticleEditPageProps {
 const ArticleEditPage: React.FC<ArticleEditPageProps> = async ({ params }) => {
   const { articleId } = await params;
 
-  const articleData = await getArticleById(articleId);
+  const articleData = await getArticleById(articleId, null);
 
   return (
     <ArticleWritePage

--- a/blog/src/entities/article/model/getArticleById.ts
+++ b/blog/src/entities/article/model/getArticleById.ts
@@ -7,23 +7,42 @@ import { snakeToCamel } from "@/shared/util";
 
 export const getArticleById = async (
   articleId: string,
-  status?: "published" | "draft"
+  status: "published" | "draft" | null
 ) => {
   const supabase = createBrowserSupabase();
 
-  const { data, error } = await supabase
-    .from("articles")
-    .select(
-      `
+  let selectArticleByIdResponse;
+
+  if (status === null) {
+    selectArticleByIdResponse = await supabase
+      .from("articles")
+      .select(
+        `
         id , title , author , 
         series_name , description , 
         status , updated_at, thumbnail_url,
         content, article_tags(tag_name)
       `
-    )
-    .eq("status", status || "published")
-    .eq("id", +articleId)
-    .single();
+      )
+      .eq("id", +articleId)
+      .single();
+  } else {
+    selectArticleByIdResponse = await supabase
+      .from("articles")
+      .select(
+        `
+        id , title , author , 
+        series_name , description , 
+        status , updated_at, thumbnail_url,
+        content, article_tags(tag_name)
+      `
+      )
+      .eq("status", status)
+      .eq("id", +articleId)
+      .single();
+  }
+
+  const { data, error } = selectArticleByIdResponse;
 
   if (error) {
     throw error;


### PR DESCRIPTION
This pull request includes several changes to the `blog` application, primarily focusing on updating the `getArticleById` function to handle different article statuses and improving import paths. The most important changes include modifying the `getArticleById` function to accept `null` as a status, updating the `ArticlePage` and `ArticleEditPage` components to use the new `getArticleById` function signature, and improving import paths for better code organization.

Changes to `getArticleById` function:

* [`blog/src/entities/article/model/getArticleById.ts`](diffhunk://#diff-7ce1f4117c96af21b3f8887c490d3123162381b54adb007bd4997684c22fccd0L10-R30): Modified the `getArticleById` function to accept `null` as a status, allowing it to fetch articles regardless of their status. [[1]](diffhunk://#diff-7ce1f4117c96af21b3f8887c490d3123162381b54adb007bd4997684c22fccd0L10-R30) [[2]](diffhunk://#diff-7ce1f4117c96af21b3f8887c490d3123162381b54adb007bd4997684c22fccd0L24-R45)

Updates to components:

* `blog/app/article/[articleId]/page.tsx`: Updated the `ArticlePage` component to call `getArticleById` with "published" status. ([blog/app/article/[articleId]/page.tsxL12-R12](diffhunk://#diff-dbf88431f7aee9b1a56783ea34cb3220b852074065713dce9f69884559253c0fL12-R12))
* `blog/app/write/[articleId]/page.tsx`: Updated the `ArticleEditPage` component to call `getArticleById` with `null` status. ([blog/app/write/[articleId]/page.tsxL14-R14](diffhunk://#diff-436a866359068325e46c043125bbc79c062e96c03c629e9aff4228f5a7b2652bL14-R14))

Improvements to import paths:

* [`blog/app/temp/page.tsx`](diffhunk://#diff-1e425d65ed171d9f86de58886b8501b5b965be7c8616d895da1e67f614f9dc05L3-R3): Simplified the import path for `TempArticleListView`.