### PR TITLE
[Fix] popular 아티클 invalidate 되지 않던 버그 수정 

### DIFF
--- a/blog/src/entities/article/model/articleQueryKey.ts
+++ b/blog/src/entities/article/model/articleQueryKey.ts
@@ -24,10 +24,12 @@ export const ARTICLE_QUERY_KEY = {
   listSeries: (status: ArticleStatus, series: string) =>
     [...ARTICLE_QUERY_KEY.default(status), "list", { series }] as const,
 
+  popularDefault: () => ["popular"] as const,
+
   // 인기글 같은 경우엔 자주 invalidate 될 필요 없다.
   // 인기글의 invalidate 는 ISR과 GA 를 통해 변경하도록 한다.
   popular: (period: "daily" | "weekly" | "monthly") =>
-    [`popular article ${period}`] as const,
+    [...ARTICLE_QUERY_KEY.popularDefault(), period] as const,
 
   infoPerSeries: () =>
     [...ARTICLE_QUERY_KEY.default("published"), "perSeries"] as const

--- a/blog/src/slots/[article]/ui/AdminArticleHeader.tsx
+++ b/blog/src/slots/[article]/ui/AdminArticleHeader.tsx
@@ -38,6 +38,11 @@ export const AdminArticleHeader: React.FC<AdminArticleHeaderProps> = ({
               isTempArticle ? "draft" : "published"
             )
           });
+
+          queryClient.invalidateQueries({
+            queryKey: ARTICLE_QUERY_KEY.popularDefault()
+          });
+
           router.back();
         }
       });

--- a/blog/src/slots/write/ui/ArticleWrite.tsx
+++ b/blog/src/slots/write/ui/ArticleWrite.tsx
@@ -6,6 +6,7 @@ import {
   useArticleWriteStore
 } from "../model";
 import { SeriesSelectToggle, TagSelectToggle } from "./items";
+import { useQueryClient } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import React, { useContext, useEffect, useRef } from "react";
 
@@ -19,6 +20,7 @@ import {
   usePostArticleThumbnail,
   usePostNewArticle
 } from "@/entities/article/model";
+import { ARTICLE_QUERY_KEY } from "@/entities/article/model/articleQueryKey";
 import { compressImage } from "@/entities/image/lib";
 import {
   ImageGrid,
@@ -530,6 +532,7 @@ const SubmitButton = () => {
   const router = useRouter();
   const { mutate: addNewArticle } = usePostNewArticle();
   const store = useContext(ArticleWriteStoreContext)!;
+  const queryClient = useQueryClient();
 
   const handleSaveArticle = () => {
     const {
@@ -569,6 +572,10 @@ const SubmitButton = () => {
       {
         onSuccess: (data) => {
           alert(data.message);
+
+          queryClient.invalidateQueries({
+            queryKey: ARTICLE_QUERY_KEY.popularDefault()
+          });
           router.push("/");
         }
       }


### PR DESCRIPTION
This pull request includes several changes to the `blog` project, focusing on the `article` entity and its related components. The most important changes include adding a new query key for popular articles, updating the query invalidation logic, and importing necessary dependencies.

### Changes to `article` entity and query keys:

* [`blog/src/entities/article/model/articleQueryKey.ts`](diffhunk://#diff-2c67ac42668db9d6ceabd918d6f6603c54c5a9845aed9f206467951fd017a27dR27-R32): Added a new query key `popularDefault` for popular articles and updated the `popular` query key to use this new key.

### Query invalidation logic updates:

* `blog/src/slots/[article]/ui/AdminArticleHeader.tsx`: Added logic to invalidate queries using the new `popularDefault` key when an article's status is updated. ([blog/src/slots/[article]/ui/AdminArticleHeader.tsxR41-R45](diffhunk://#diff-6e201f7c7422d892da731ca912dde100873f727ae98533a69c13c275aa4632a8R41-R45))
* [`blog/src/slots/write/ui/ArticleWrite.tsx`](diffhunk://#diff-c06c43e56ce72b8e662ed0dbf877873f5f967bb28bf3ab2da4469b91fa858d06R575-R578): Added logic to invalidate queries using the new `popularDefault` key upon successfully saving a new article.

### Dependency imports:

* [`blog/src/slots/write/ui/ArticleWrite.tsx`](diffhunk://#diff-c06c43e56ce72b8e662ed0dbf877873f5f967bb28bf3ab2da4469b91fa858d06R9): Imported `useQueryClient` from `@tanstack/react-query` and `ARTICLE_QUERY_KEY` from the `articleQueryKey` module. [[1]](diffhunk://#diff-c06c43e56ce72b8e662ed0dbf877873f5f967bb28bf3ab2da4469b91fa858d06R9) [[2]](diffhunk://#diff-c06c43e56ce72b8e662ed0dbf877873f5f967bb28bf3ab2da4469b91fa858d06R23) [[3]](diffhunk://#diff-c06c43e56ce72b8e662ed0dbf877873f5f967bb28bf3ab2da4469b91fa858d06R535)