### PR TITLE
[Feat] 불필요한 CSS 제거 & 다크모드 스크립트 생성

### DIFF
--- a/blog/app/layout.tsx
+++ b/blog/app/layout.tsx
@@ -1,15 +1,9 @@
 import { Header } from "./Header";
 import "./globals.css";
-import { Noto_Sans_KR } from "next/font/google";
 
 import { ServiceProvider } from "@/app/ServiceProvider";
 
 import { GithubIcon, HumanIcon } from "@/shared/config";
-
-const notoSans = Noto_Sans_KR({
-  display: "swap",
-  subsets: ["latin"]
-});
 
 interface RootLayoutProps {
   children: React.ReactNode;
@@ -18,7 +12,7 @@ interface RootLayoutProps {
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children, modal }) => {
   return (
-    <html className={notoSans.className}>
+    <html>
       <body className="flex min-h-screen flex-col bg-primary">
         <ServiceProvider>
           <Header />

--- a/blog/app/layout.tsx
+++ b/blog/app/layout.tsx
@@ -3,6 +3,8 @@ import "./globals.css";
 
 import { ServiceProvider } from "@/app/ServiceProvider";
 
+import { DarkModeInitializeScript } from "@/features/utils/ui";
+
 import { GithubIcon, HumanIcon } from "@/shared/config";
 
 interface RootLayoutProps {
@@ -12,8 +14,9 @@ interface RootLayoutProps {
 
 const RootLayout: React.FC<RootLayoutProps> = ({ children, modal }) => {
   return (
-    <html>
+    <html suppressHydrationWarning>
       <body className="flex min-h-screen flex-col bg-primary">
+        <DarkModeInitializeScript />
         <ServiceProvider>
           <Header />
           <main className="flex flex-grow flex-col">

--- a/blog/src/features/utils/ui/DarkModeInitializeScript.tsx
+++ b/blog/src/features/utils/ui/DarkModeInitializeScript.tsx
@@ -1,0 +1,20 @@
+export const DarkModeInitializeScript = () => {
+  return (
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
+        const localStorageSavedTheme = localStorage.getItem("abonglog-theme");
+        const userPrefersDark = window.matchMedia(
+          "(prefers-color-scheme: dark)"
+        ).matches;
+      
+        const isDarkMode = localStorageSavedTheme === "dark" || userPrefersDark;
+      
+        if (isDarkMode) {
+          document.documentElement.classList.add("dark");
+        }
+      `
+      }}
+    />
+  );
+};

--- a/blog/src/features/utils/ui/DarkModeToggle.tsx
+++ b/blog/src/features/utils/ui/DarkModeToggle.tsx
@@ -4,11 +4,15 @@ import { useState } from "react";
 import { FaMoon, FaSun } from "react-icons/fa";
 
 export const DarkModeToggle = () => {
-  const [isDarkMode, setIsDarkMode] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(
+    () =>
+      localStorage.getItem("abonglog-theme") === "dark" ||
+      window.matchMedia("(prefers-color-scheme: dark)").matches
+  );
 
   const toggleDarkMode = () => {
-    setIsDarkMode(!isDarkMode);
     document.documentElement.classList.toggle("dark");
+    setIsDarkMode(!isDarkMode);
     localStorage.setItem("abonglog-theme", isDarkMode ? "light" : "dark");
   };
 

--- a/blog/src/features/utils/ui/DarkModeToggle.tsx
+++ b/blog/src/features/utils/ui/DarkModeToggle.tsx
@@ -1,14 +1,20 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FaMoon, FaSun } from "react-icons/fa";
 
 export const DarkModeToggle = () => {
-  const [isDarkMode, setIsDarkMode] = useState(
-    () =>
-      localStorage.getItem("abonglog-theme") === "dark" ||
-      window.matchMedia("(prefers-color-scheme: dark)").matches
-  );
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    const localStorageSavedTheme = localStorage.getItem("abonglog-theme");
+    const userPrefersDark = window.matchMedia(
+      "(prefers-color-scheme: dark)"
+    ).matches;
+
+    const isDarkMode = localStorageSavedTheme === "dark" || userPrefersDark;
+    setIsDarkMode(isDarkMode);
+  }, []);
 
   const toggleDarkMode = () => {
     document.documentElement.classList.toggle("dark");

--- a/blog/src/features/utils/ui/DarkModeToggle.tsx
+++ b/blog/src/features/utils/ui/DarkModeToggle.tsx
@@ -1,32 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { FaMoon, FaSun } from "react-icons/fa";
 
 export const DarkModeToggle = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
-  useEffect(() => {
-    const savedMode = localStorage.getItem("abonglog-theme");
-    if (savedMode) {
-      setIsDarkMode(savedMode === "dark");
-      if (savedMode === "dark") {
-        document.documentElement.classList.add("dark");
-      } else {
-        document.documentElement.classList.remove("dark");
-      }
-    }
-  }, []);
-
   const toggleDarkMode = () => {
-    const newMode = isDarkMode ? "light" : "dark";
     setIsDarkMode(!isDarkMode);
-    if (newMode === "dark") {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
-    localStorage.setItem("abonglog-theme", newMode);
+    document.documentElement.classList.toggle("dark");
+    localStorage.setItem("abonglog-theme", isDarkMode ? "light" : "dark");
   };
 
   return (

--- a/blog/src/features/utils/ui/index.ts
+++ b/blog/src/features/utils/ui/index.ts
@@ -1,1 +1,2 @@
 export * from "./DarkModeToggle";
+export * from "./DarkModeInitializeScript";

--- a/blog/src/slots/[article]/ui/ArticleSlot.tsx
+++ b/blog/src/slots/[article]/ui/ArticleSlot.tsx
@@ -35,7 +35,7 @@ export const ArticleSlot: React.FC<ArticlePageProps> = async ({
           <Image
             src={thumbnailUrl}
             alt={`${title} 의 썸네일`}
-            className="h-96 w-full object-contain"
+            className="h-96 w-full object-cover"
             width={1080}
             height={500}
             priority={true}


### PR DESCRIPTION
This pull request includes multiple changes to the `blog` application, primarily focusing on adding dark mode functionality and improving the UI. The most important changes include the addition of a dark mode initialization script, modifications to the dark mode toggle, and updates to the layout and styles.

### Dark Mode Functionality:

* [`blog/app/layout.tsx`](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL3-R8): Added `DarkModeInitializeScript` and removed the `Noto_Sans_KR` font import. Updated the `html` element to suppress hydration warning and included the dark mode initialization script. [[1]](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL3-R8) [[2]](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL21-R19)
* [`blog/src/features/utils/ui/DarkModeInitializeScript.tsx`](diffhunk://#diff-5bfc9e2316e6f67d6ee59e8ed1df146f15c3bec892f7e5f9b8310daa3928b21fR1-R20): Created a new component to initialize dark mode based on user preference or saved theme in local storage.
* [`blog/src/features/utils/ui/DarkModeToggle.tsx`](diffhunk://#diff-0bb55ce7cf31195c32195674b9576781ad2f4f3d452ade703c72a9c1662ebf0fL3-R12): Simplified the dark mode toggle by removing the `useEffect` hook and directly toggling the dark mode class on the `document.documentElement`.
* [`blog/src/features/utils/ui/index.ts`](diffhunk://#diff-86c271dc2e89191131fedd5ecc5623fdbcaebf43f6c239b38658944b55c3b9d0R2): Exported the new `DarkModeInitializeScript` component.

### UI Improvements:

* `blog/src/slots/[article]/ui/ArticleSlot.tsx`: Updated the `Image` component's class to use `object-cover` instead of `object-contain` for better image presentation. ([blog/src/slots/[article]/ui/ArticleSlot.tsxL38-R38](diffhunk://#diff-381082be1fb15f80f988e16501f2ecfd5f5446e8c8eff17042bf947d424a6e92L38-R38))