### PR TITLE
[Fix] 다크모드 올바르게 초기화되지 않거나 토글되지 않는 버그 수정

### DIFF
--- a/blog/src/features/utils/ui/DarkModeInitializeScript.tsx
+++ b/blog/src/features/utils/ui/DarkModeInitializeScript.tsx
@@ -4,6 +4,11 @@ export const DarkModeInitializeScript = () => {
       dangerouslySetInnerHTML={{
         __html: `
         const localStorageSavedTheme = localStorage.getItem("abonglog-theme");
+        
+        if (localStorageSavedTheme === 'light') {
+          return;
+        }
+        
         const userPrefersDark = window.matchMedia(
           "(prefers-color-scheme: dark)"
         ).matches;

--- a/blog/src/features/utils/ui/DarkModeToggle.tsx
+++ b/blog/src/features/utils/ui/DarkModeToggle.tsx
@@ -7,18 +7,14 @@ export const DarkModeToggle = () => {
   const [isDarkMode, setIsDarkMode] = useState(false);
 
   useEffect(() => {
-    const localStorageSavedTheme = localStorage.getItem("abonglog-theme");
-    const userPrefersDark = window.matchMedia(
-      "(prefers-color-scheme: dark)"
-    ).matches;
-
-    const isDarkMode = localStorageSavedTheme === "dark" || userPrefersDark;
-    setIsDarkMode(isDarkMode);
+    // 다크모드 여부는 html이 파싱되는 동안 DarkModeInitializeScript에서 설정되므로
+    // document.classList에 dark 클래스가 있는지 확인하면 된다.
+    setIsDarkMode(document.documentElement.classList.contains("dark"));
   }, []);
 
   const toggleDarkMode = () => {
+    setIsDarkMode((prev) => !prev);
     document.documentElement.classList.toggle("dark");
-    setIsDarkMode(!isDarkMode);
     localStorage.setItem("abonglog-theme", isDarkMode ? "light" : "dark");
   };
 

--- a/blog/src/features/utils/ui/DarkModeToggle.tsx
+++ b/blog/src/features/utils/ui/DarkModeToggle.tsx
@@ -15,7 +15,10 @@ export const DarkModeToggle = () => {
   const toggleDarkMode = () => {
     setIsDarkMode((prev) => !prev);
     document.documentElement.classList.toggle("dark");
-    localStorage.setItem("abonglog-theme", isDarkMode ? "light" : "dark");
+
+    // 컨텍스트를 유지 할 수 있도록 안젆게 nextIsDarkMode를 사용한다.
+    const nextIsDarkMode = !isDarkMode;
+    localStorage.setItem("abonglog-theme", nextIsDarkMode ? "dark" : "light");
   };
 
   return (


### PR DESCRIPTION
This pull request includes changes to the dark mode initialization and toggle functionality in the `blog/src/features/utils/ui` directory. The most important changes include simplifying the dark mode initialization script and improving the dark mode toggle logic.

Improvements to dark mode initialization:

* [`blog/src/features/utils/ui/DarkModeInitializeScript.tsx`](diffhunk://#diff-5bfc9e2316e6f67d6ee59e8ed1df146f15c3bec892f7e5f9b8310daa3928b21fR7-R11): Added a check to return early if the saved theme in local storage is 'light'.

Improvements to dark mode toggle logic:

* [`blog/src/features/utils/ui/DarkModeToggle.tsx`](diffhunk://#diff-0bb55ce7cf31195c32195674b9576781ad2f4f3d452ade703c72a9c1662ebf0fL10-L21): Updated the `useEffect` hook to check for the 'dark' class on the document element instead of re-evaluating the theme preference. Simplified the `toggleDarkMode` function to update the state before toggling the document class and saving the theme in local storage.