### PR TITLE
[Feat] 코드 스니펫 UI 변경 및 하이라이트 코드 추가

### DIFF
--- a/blog/app/globals.css
+++ b/blog/app/globals.css
@@ -255,17 +255,17 @@ pre[data-language] code[data-language] {
 
 /* add, remove , pointing 마다 배경색 설정 */
 pre[data-language] code[data-language] span[data-highlighted-line-id="add"] {
-  background-color: rgba(129, 199, 132, 0.4);
+  background-color: rgba(129, 199, 132, 0.3);
 }
 
 pre[data-language] code[data-language] span[data-highlighted-line-id="remove"] {
-  background-color: rgba(229, 115, 115, 0.4);
+  background-color: rgba(229, 115, 115, 0.3);
 }
 
 pre[data-language]
   code[data-language]
   span[data-highlighted-line-id="pointing"] {
-  background-color: rgba(79, 195, 247, 0.2);
+  background-color: rgba(79, 195, 247, 0.3);
 }
 
 pre[data-language] code[data-language] span[data-line] {

--- a/blog/app/globals.css
+++ b/blog/app/globals.css
@@ -238,7 +238,7 @@ p {
   text-align: right;
   width: 100%;
   display: block;
-  padding: 0.5rem 0;
+  padding: 0.5rem 0 0.2rem 0;
 }
 
 /* 라인 줄 간격 설정 */
@@ -292,7 +292,7 @@ figcaption[data-rehype-pretty-code-title] {
   color: #ddd;
   background-color: var(--code-background);
   display: inline-block;
-  padding: 0.5rem 2.5rem 0.5rem 1rem;
+  padding: 0.5rem 1rem;
   border-radius: 1rem 1rem 0 0; /* 오른쪽 상단 모서리 반지름 증가 */
 }
 

--- a/blog/app/globals.css
+++ b/blog/app/globals.css
@@ -35,6 +35,8 @@
     0 1px 3px rgba(255, 255, 255, 0.1), 0 1px 2px rgba(255, 255, 255, 0.06);
 
   --selection-bg: #d3d3d3;
+
+  --code-background: #383a42;
 }
 .dark {
   --bg-primary: var(--bg-dark-primary);
@@ -224,7 +226,7 @@ p {
   border-radius: 0 0.5rem 0.5rem 0.5rem;
   padding: 0 2rem 1rem 1rem;
   overflow: auto;
-  background-color: #212121;
+  background-color: var(--code-background);
   font-style: normal;
   font-size: 1.1rem;
   font-family: "VictorMono", transparent;
@@ -251,6 +253,21 @@ pre[data-language] code[data-language] {
   display: grid; /* 그리드 레이아웃 사용 */
 }
 
+/* add, remove , pointing 마다 배경색 설정 */
+pre[data-language] code[data-language] span[data-highlighted-line-id="add"] {
+  background-color: rgba(129, 199, 132, 0.4);
+}
+
+pre[data-language] code[data-language] span[data-highlighted-line-id="remove"] {
+  background-color: rgba(229, 115, 115, 0.4);
+}
+
+pre[data-language]
+  code[data-language]
+  span[data-highlighted-line-id="pointing"] {
+  background-color: rgba(79, 195, 247, 0.2);
+}
+
 pre[data-language] code[data-language] span[data-line] {
   counter-increment: line-number; /* 라인 번호 카운터 증가 */
 }
@@ -273,7 +290,7 @@ figcaption[data-rehype-pretty-code-title] {
   font-size: 1rem;
   font-weight: bold;
   color: #ddd;
-  background-color: #212121;
+  background-color: var(--code-background);
   display: inline-block;
   padding: 0.5rem 2.5rem 0.5rem 1rem;
   border-radius: 1rem 1rem 0 0; /* 오른쪽 상단 모서리 반지름 증가 */


### PR DESCRIPTION
This pull request includes several changes to the `blog/app/globals.css` file, primarily focusing on improving the styling of code blocks and their background colors. The most important changes involve the introduction of a new CSS variable for code backgrounds and adjustments to padding and background colors for various elements.

Styling improvements:

* Added a new CSS variable `--code-background` for code block backgrounds.
* Updated the background color of `p` elements to use the new `--code-background` variable instead of a hardcoded color.
* Adjusted the padding of `p` elements to improve spacing.
* Added background colors for spans with `data-highlighted-line-id` attributes within code blocks to visually distinguish added, removed, and pointing lines.
* Modified the background color and padding of `figcaption` elements with `data-rehype-pretty-code-title` to use the new `--code-background` variable and improve spacing.