### PR TITLE
[Fix] 줄바꿈이 된 이미지 경로를 인식하지 못해 게시글이 저장 될 때 이미지가 제거되던 버그 수정

### DIFF
--- a/blog/backend/image/lib/findStoredImageName.test.ts
+++ b/blog/backend/image/lib/findStoredImageName.test.ts
@@ -1,0 +1,18 @@
+import { findStoredImageName } from "./findStoredImageName";
+
+import { SUPABASE_STORAGE_URL } from "@/shared/config";
+
+describe("findStoredImageName", () => {
+  it("줄 바꿈이 되어있는 이미지 경로도 올바르게 인식한다.", () => {
+    const imageAlt = "alt";
+    const imageName = "1.png";
+    //  줄바꿈이 되어있는 imagePath
+    const imagePath = `${SUPABASE_STORAGE_URL}
+    /blahblah/blahblah/${imageName}
+    `;
+    const content = `![${imageAlt}](${imagePath})`;
+
+    const expected = [imageName];
+    expect(findStoredImageName(content)).toEqual(expected);
+  });
+});

--- a/blog/src/features/article/lib/findImageUrl.test.ts
+++ b/blog/src/features/article/lib/findImageUrl.test.ts
@@ -1,6 +1,8 @@
 import { findImageUrl } from "./findImageUrl";
 import { describe, it } from "@jest/globals";
 
+import { SUPABASE_STORAGE_URL } from "@/shared/config";
+
 describe("findImageUrl test", () => {
   it("이미지 문구가 없는 경우 findImageUrl 은 빈 배열을 반환한다.", () => {
     const text = `
@@ -40,5 +42,23 @@ describe("findImageUrl test", () => {
       { alt: "alt2_1", src: "https://image2.com" },
       { alt: "alt3_1", src: "https://image3.com" }
     ]);
+  });
+
+  it("줄바꿈이 되어있는 이미지 경로도 올바르게 인식한다.", () => {
+    const imageAlt = "alt";
+    const imageName = "1.png";
+    //  줄바꿈이 되어있는 imagePath
+    const imagePath = `${SUPABASE_STORAGE_URL}
+    /${imageName}
+    `;
+    const content = `![${imageAlt}](${imagePath})`;
+
+    const expected = [
+      {
+        alt: imageAlt,
+        src: `${SUPABASE_STORAGE_URL}/${imageName}`
+      }
+    ];
+    expect(findImageUrl(content)).toEqual(expected);
   });
 });

--- a/blog/src/features/article/lib/findImageUrl.ts
+++ b/blog/src/features/article/lib/findImageUrl.ts
@@ -1,17 +1,17 @@
 export const findImageUrl = (markdown: string) => {
-  // ![]() 로 시작하는 모든 문구 찾기
-  const regExp = /!\[.*?\]\(.*?\)/g;
-  const matches = markdown.match(regExp);
+  // 줄바꿈과 공백을 포함하여 매칭하도록 수정
+  const regExp = /!\[(.*?)\]\(([\s\S]*?)\)/g;
+  const matches = Array.from(markdown.matchAll(regExp));
 
-  if (!matches) {
+  if (!matches.length) {
     return [];
   }
 
-  // [] 안에 있는 alt, () 안에 있는 url 추출
   return matches
-    .map((text) => ({
-      src: (text.match(/\((.*?)\)/) || [])[1]!,
-      alt: (text.match(/\[(.*?)\]/) || [])[1]!
+    .map((match) => ({
+      alt: match[1].trim(),
+      // URL에서 줄바꿈과 공백 제거
+      src: match[2].replace(/[\n\r\s]+/g, "")
     }))
     .reduce(
       (result, image) => {


### PR DESCRIPTION
This pull request includes changes to improve the handling of image paths with line breaks in the `findStoredImageName` and `findImageUrl` functions. The most important changes include adding tests for these functions and modifying the regular expression used in `findImageUrl` to match image paths with line breaks and spaces.

### Improvements to image path handling:

* [`blog/backend/image/lib/findStoredImageName.test.ts`](diffhunk://#diff-32c35d20c51789957b39f6d0117ca4d7cb641523e193f4068ccf8721d3afdb0dR1-R18): Added a test to ensure `findStoredImageName` correctly identifies image paths with line breaks.
* [`blog/src/features/article/lib/findImageUrl.test.ts`](diffhunk://#diff-b06825b0b5ef169f195516cc221b936087ebe891c06fd5b937b2ecda8693d1b7R46-R63): Added a test to ensure `findImageUrl` correctly identifies image paths with line breaks.

### Codebase modifications:

* [`blog/src/features/article/lib/findImageUrl.ts`](diffhunk://#diff-db913180de61924594282b2107bb2193ec5b4fec5a86c9c3de38a56b18a82402L2-R14): Modified the regular expression in `findImageUrl` to match image paths with line breaks and spaces, and updated the function to remove line breaks and spaces from the URL.
* [`blog/src/features/article/lib/findImageUrl.test.ts`](diffhunk://#diff-b06825b0b5ef169f195516cc221b936087ebe891c06fd5b937b2ecda8693d1b7R4-R5): Imported `SUPABASE_STORAGE_URL` from shared configuration to use in the tests.