### PR TITLE
[Feat] 이미지 화질 저하 되던 문제 제거

### DIFF
--- a/blog/app/api/images/[articleId]/[imageId]/route.ts
+++ b/blog/app/api/images/[articleId]/[imageId]/route.ts
@@ -1,10 +1,8 @@
-import { resizeAndConvertToWebp } from "@backend/image/lib";
 import { downloadImage } from "@backend/image/model";
 import { createErrorResponse } from "@backend/shared/lib";
 import { NextRequest, NextResponse } from "next/server";
 
 const STORAGE_NAME = "article_image";
-const BASE_IMAGE_WIDTH = 1000;
 const getStoragePath = (articleId: string, imageId: string) => {
   return `images/${articleId}/${imageId}`;
 };
@@ -36,25 +34,6 @@ export const GET = async (
     return createErrorResponse(error);
   }
 
-  const contentType = imageData.type;
-  if (contentType === "image/gif") {
-    return NextResponse.json(
-      {
-        code: 400,
-        message: "GIF 이미지는 리사이징할 수 없습니다."
-      },
-      {
-        status: 400
-      }
-    );
-  }
-
-  const resizedImage = await resizeAndConvertToWebp(
-    imageData,
-    parseInt(width, 10) || BASE_IMAGE_WIDTH,
-    100
-  );
-
   const cacheKey = `${articleId}-${imageId}-${width}`;
   const cacheHeaders = {
     "Cache-Control": "public, max-age=31536000, immutable",
@@ -66,7 +45,7 @@ export const GET = async (
     Vary: "Accept-Encoding"
   };
 
-  return new NextResponse(resizedImage, {
+  return new NextResponse(imageData, {
     status: 200,
     headers: cacheHeaders
   });

--- a/blog/app/api/thumbnails/[articleId]/[imageId]/route.ts
+++ b/blog/app/api/thumbnails/[articleId]/[imageId]/route.ts
@@ -1,10 +1,8 @@
-import { resizeAndConvertToWebp } from "@backend/image/lib";
 import { downloadImage } from "@backend/image/model";
 import { createErrorResponse } from "@backend/shared/lib";
 import { NextRequest, NextResponse } from "next/server";
 
 const STORAGE_NAME = "article_thumbnail";
-const BASE_IMAGE_WIDTH = 1000;
 
 const getStoragePath = (articleId: string, imageId: string) => {
   return `thumbnails/${articleId}/${imageId}`;
@@ -38,12 +36,6 @@ export const GET = async (
     });
   }
 
-  const resizedImage = await resizeAndConvertToWebp(
-    imageData,
-    parseInt(width, 10) || BASE_IMAGE_WIDTH,
-    100
-  );
-
   const cacheKey = `${articleId}-${imageId}-${width}`;
   const cacheHeaders = {
     "Cache-Control": "public, max-age=31536000, immutable",
@@ -55,7 +47,7 @@ export const GET = async (
     Vary: "Accept-Encoding"
   };
 
-  return new NextResponse(resizedImage, {
+  return new NextResponse(imageData, {
     status: 200,
     headers: cacheHeaders
   });

--- a/blog/next.config.ts
+++ b/blog/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    deviceSizes: [1200, 1600, 2400],
+    deviceSizes: [600, 1200, 1600, 2400],
     imageSizes: [],
     remotePatterns:
       process.env.NODE_ENV === "development"

--- a/blog/next.config.ts
+++ b/blog/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    deviceSizes: [750, 900, 1080, 1200, 1920, 2048, 3840],
+    deviceSizes: [1200, 1600, 2400],
     imageSizes: [],
     remotePatterns:
       process.env.NODE_ENV === "development"

--- a/blog/src/entities/article/lib/components.tsx
+++ b/blog/src/entities/article/lib/components.tsx
@@ -200,10 +200,11 @@ const ArticlePhoto: FC<ImageProps> = ({ src, alt, ...props }) => {
         src={src}
         alt={alt}
         {...props}
-        width={1200}
-        height={630}
+        width={2400}
+        height={1260}
         className="mx-auto w-fit min-w-[50%] rounded-lg"
-        sizes="(max-width: 1200px) 100vw, 1200px"
+        // 픽셀 밀도를 고려하여 원하는 이미지 크기 * 2 만큼의 sizes 고려
+        sizes="(max-width: 600px) 1200px , (max-width: 800px) 1600px , 2400px"
         aria-describedby={`caption-${randomImageId}`}
         quality={100}
       />

--- a/blog/src/entities/article/lib/components.tsx
+++ b/blog/src/entities/article/lib/components.tsx
@@ -195,14 +195,14 @@ const ArticlePhoto: FC<ImageProps> = ({ src, alt, ...props }) => {
   }
 
   return (
-    <span className="flex flex-col">
+    <span className="flex w-full flex-col">
       <Image
         src={src}
         alt={alt}
         {...props}
-        width={2400}
-        height={1260}
-        className="mx-auto w-fit min-w-[50%] rounded-lg"
+        width={1200}
+        height={620}
+        className="mx-auto w-fit rounded-lg"
         // 픽셀 밀도를 고려하여 원하는 이미지 크기 * 2 만큼의 sizes 고려
         sizes="(max-width: 600px) 1200px , (max-width: 800px) 1600px , 2400px"
         aria-describedby={`caption-${randomImageId}`}

--- a/blog/src/slots/[article]/ui/ArticleSlot.tsx
+++ b/blog/src/slots/[article]/ui/ArticleSlot.tsx
@@ -32,15 +32,16 @@ export const ArticleSlot: React.FC<ArticlePageProps> = async ({
       <header>
         {/* 썸네일 이미지 */}
         {thumbnailUrl ? (
-          <Image
-            src={thumbnailUrl}
-            alt={`${title} 의 썸네일`}
-            className="h-96 w-full object-cover"
-            width={1080}
-            height={500}
-            priority={true}
-            quality={100}
-          />
+          <div className="relative h-96">
+            <Image
+              src={thumbnailUrl}
+              alt={`${title} 의 썸네일`}
+              fill
+              className="object-cover"
+              priority={true}
+              quality={100}
+            />
+          </div>
         ) : (
           <div className="h-96 w-full bg-gray-200" />
         )}

--- a/blog/src/slots/main/ui/LatestArticleSlot.tsx
+++ b/blog/src/slots/main/ui/LatestArticleSlot.tsx
@@ -75,9 +75,9 @@ export const LatestArticleSlot = () => {
           <Image
             src={thumbnailUrl}
             alt={`${title} 의 썸네일 이미지`}
-            className="h-full w-full rounded-lg object-cover"
-            priority={true}
+            className="rounded-lg object-cover"
             fill
+            priority={true}
             quality={100}
           />
         ) : (

--- a/blog/src/widgets/article/ui/ArticlePreviewCard.tsx
+++ b/blog/src/widgets/article/ui/ArticlePreviewCard.tsx
@@ -33,7 +33,7 @@ export const ArticlePreviewCard: React.FC<ArticlePreviewCardProps> = ({
           className="aspect-video w-full rounded-t-lg object-cover"
           width={300}
           height={169}
-          sizes="(max-width: 500px) 300px, 600px"
+          sizes="600px"
           quality={100}
         />
       ) : (


### PR DESCRIPTION
이미지의 화질이 저하되던 버그의 원인은 픽셀 밀도를 고려하지 못했기 때문이다. 

이미지가 렌더 되는 최대 크기가 1200px 이라 할 때  `Image` 컴포넌트에서 `sizes : ... 1200px` 로 가져오도록 했는데 

각 기기별 픽셀 밀도가 2.0 일 경우 이미지의 크기를 보고자 하는 이미지 크기 * 2 의 크기로 가져와야 

선명한 이미지를 보여줄 수 있다. 

이에 각 `Image` 컴포넌트의 `sizes` 에서 픽셀 밀도를 2 씩 곱해주었다. 

> 기본 `img` 태그의 경우엔 자동으로 브라우저의 픽셀 밀도를 고려하여 적절한 `src` 를 캡쳐하지만 `Image` 태그에선 브라우저의 픽셀 밀도를 알 수 없기 때문에 정적으로 고려해줘야했다. 

추가로 이미지에 대한 `GET` 요청에서 이미지를 압축하던 과정을 제거해주었다. 

GIF이미지를 가져오는 것이 불가능했으며 , 불필요한 이중 변환 과정이 존재했기 때문이다.

---
This pull request includes several changes to the image handling and configuration in the blog application. The most important changes involve removing image resizing and conversion functionality, updating image sizes in the configuration, and modifying the layout and properties of image components.

Changes to image handling:

* Removed the `resizeAndConvertToWebp` function and associated resizing logic from `blog/app/api/images/[articleId]/[imageId]/route.ts`. ([blog/app/api/images/[articleId]/[imageId]/route.tsL1-L7](diffhunk://#diff-d260f219dbab92086015f70db2ab7cb4d3b8d4b6063f617d68cd740085581673L1-L7), [blog/app/api/images/[articleId]/[imageId]/route.tsL39-L57](diffhunk://#diff-d260f219dbab92086015f70db2ab7cb4d3b8d4b6063f617d68cd740085581673L39-L57), [blog/app/api/images/[articleId]/[imageId]/route.tsL69-R48](diffhunk://#diff-d260f219dbab92086015f70db2ab7cb4d3b8d4b6063f617d68cd740085581673L69-R48))
* Removed the `resizeAndConvertToWebp` function and associated resizing logic from `blog/app/api/thumbnails/[articleId]/[imageId]/route.ts`. ([blog/app/api/thumbnails/[articleId]/[imageId]/route.tsL1-L7](diffhunk://#diff-f708686c1ccfff01ae6c65bb255fe306a43715a5f88e40600b9df2dd812018d5L1-L7), [blog/app/api/thumbnails/[articleId]/[imageId]/route.tsL41-L46](diffhunk://#diff-f708686c1ccfff01ae6c65bb255fe306a43715a5f88e40600b9df2dd812018d5L41-L46), [blog/app/api/thumbnails/[articleId]/[imageId]/route.tsL58-R50](diffhunk://#diff-f708686c1ccfff01ae6c65bb255fe306a43715a5f88e40600b9df2dd812018d5L58-R50))

Configuration updates:

* Updated the `deviceSizes` array in `next.config.ts` to include only `[1200, 1600, 2400]`.

Component layout and properties:

* Modified the `ArticlePhoto` component in `blog/src/entities/article/lib/components.tsx` to adjust the layout, sizes, and dimensions of the image.
* Updated the `ArticleSlot` component in `blog/src/slots/[article]/ui/ArticleSlot.tsx` to include a wrapper div with a relative height for the thumbnail image. ([blog/src/slots/[article]/ui/ArticleSlot.tsxR35-R44](diffhunk://#diff-381082be1fb15f80f988e16501f2ecfd5f5446e8c8eff17042bf947d424a6e92R35-R44))
* Adjusted the `LatestArticleSlot` component in `blog/src/slots/main/ui/LatestArticleSlot.tsx` to refine the image properties.
* Changed the `ArticlePreviewCard` component in `blog/src/widgets/article/ui/ArticlePreviewCard.tsx` to update the `sizes` attribute of the image.