### PR TITLE
[Feat] CSS 수정

### DIFF
--- a/blog/app/Header.tsx
+++ b/blog/app/Header.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Link from "next/link";
 
 import { SideBar } from "@/widgets/navigate/ui";

--- a/blog/app/globals.css
+++ b/blog/app/globals.css
@@ -199,16 +199,6 @@ p {
   background-color: var(--bg-secondary);
 }
 
-.image {
-  max-width: 100%;
-  max-height: 32rem;
-  height: auto;
-  display: block;
-  margin: 2rem auto;
-  border-radius: 8px;
-  box-shadow: var(--shadow-light);
-}
-
 .bold {
   font-weight: bold;
 }

--- a/blog/app/globals.css
+++ b/blog/app/globals.css
@@ -84,6 +84,7 @@ h3 {
 
 p {
   margin-bottom: 0.5rem;
+  font-weight: 400;
 }
 
 /* 
@@ -160,7 +161,6 @@ p {
 
 .blockquote p {
   margin: 0;
-  font-size: 1rem;
 }
 
 .unordered-list,
@@ -287,6 +287,7 @@ figcaption[data-rehype-pretty-code-title] {
 }
 
 figcaption[data-rehype-pretty-code-title]::before {
-  content: "👨‍💻";
-  font-size: 1.5rem;
+  content: "🔴🟠🟢";
+  font-size: 1rem;
+  margin-right: 0.5rem;
 }

--- a/blog/app/globals.css
+++ b/blog/app/globals.css
@@ -156,11 +156,11 @@ p {
   margin: 1rem 0;
   font-style: italic;
   background-color: var(--bg-secondary);
-  border-radius: 8px;
 }
 
 .blockquote p {
   margin: 0;
+  font-size: 1rem;
 }
 
 .unordered-list,

--- a/blog/app/layout.tsx
+++ b/blog/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Header } from "./Header";
 import "./globals.css";
 import { HydrationBoundary } from "@tanstack/react-query";
-import { IBM_Plex_Sans_KR } from "next/font/google";
+import { Gothic_A1 } from "next/font/google";
 import { Suspense } from "react";
 
 import { ServiceProvider } from "@/app/ServiceProvider";
@@ -13,10 +13,10 @@ import { getArticleMetaListPerSeries } from "@/entities/article/model";
 import { GithubIcon, HumanIcon } from "@/shared/config";
 import { prefetchQueryInServer } from "@/shared/model";
 
-const IBMPlex = IBM_Plex_Sans_KR({
+const GothicA1 = Gothic_A1({
   subsets: ["latin"],
   display: "swap",
-  weight: ["500", "600", "700"]
+  weight: ["400", "700"]
 });
 
 interface RootLayoutProps {
@@ -28,7 +28,7 @@ const RootLayout: React.FC<RootLayoutProps> = async ({ children, modal }) => {
   const sidebarState = await prefetchQueryInServer(getArticleMetaListPerSeries);
 
   return (
-    <html suppressHydrationWarning className={IBMPlex.className}>
+    <html suppressHydrationWarning className={GothicA1.className}>
       <body className="flex min-h-screen flex-col bg-primary">
         <DarkModeInitializeScript />
         <ServiceProvider>

--- a/blog/src/entities/article/lib/rehypeMarkdown.ts
+++ b/blog/src/entities/article/lib/rehypeMarkdown.ts
@@ -28,7 +28,7 @@ export const rehypeMarkdown = async (markdown: string) => {
     // 코드 블럭을 예쁘게 표현하기 위한 설정을 추가 합니다.
     .use(rehypePrettyCode, {
       grid: true,
-      theme: "tokyo-night",
+      theme: "one-dark-pro",
       keepBackground: false,
       bypassInlineCode: false,
       defaultLang: {

--- a/blog/src/entities/series/ui/SeriesItem.tsx
+++ b/blog/src/entities/series/ui/SeriesItem.tsx
@@ -12,7 +12,7 @@ export const SeriesItem: React.FC<SeriesItemProps> = ({
   updatedAt
 }) => {
   return (
-    <div className="transtiion-all flex flex-grow transform flex-col gap-2 rounded-lg border bg-primary p-4 transition-transform duration-200 hover:scale-105">
+    <div className="transtion-all flex flex-grow transform flex-col gap-2 rounded-lg border bg-primary p-4 transition-transform duration-200 hover:scale-105">
       <div className="flex items-center gap-2">
         <h3 className="font-semibold text-primary">{seriesName}</h3>
         <span className="text-sm text-tertiary">({numOfArticles})</span>

--- a/blog/src/entities/series/ui/SeriesItem.tsx
+++ b/blog/src/entities/series/ui/SeriesItem.tsx
@@ -12,7 +12,7 @@ export const SeriesItem: React.FC<SeriesItemProps> = ({
   updatedAt
 }) => {
   return (
-    <div className="flex flex-grow transform flex-col gap-2 rounded-lg border bg-primary p-4 shadow-md transition-transform hover:bg-secondary">
+    <div className="transtiion-all flex flex-grow transform flex-col gap-2 rounded-lg border bg-primary p-4 transition-transform duration-200 hover:scale-105">
       <div className="flex items-center gap-2">
         <h3 className="font-semibold text-primary">{seriesName}</h3>
         <span className="text-sm text-tertiary">({numOfArticles})</span>

--- a/blog/src/widgets/article/ui/ArticlePreviewCard.tsx
+++ b/blog/src/widgets/article/ui/ArticlePreviewCard.tsx
@@ -24,7 +24,7 @@ export const ArticlePreviewCard: React.FC<ArticlePreviewCardProps> = ({
   updatedAt
 }) => {
   return (
-    <section className="transition-bg flex h-full flex-col justify-between rounded-lg border shadow-md hover:bg-secondary hover:shadow-lg">
+    <section className="transition-bg flex h-full flex-col justify-between rounded-lg border transition-all duration-200 hover:scale-105 hover:bg-secondary">
       {/* 이미지 컴포넌트 */}
       {thumbnailUrl ? (
         <Image

--- a/blog/src/widgets/navigate/ui/SideBar.tsx
+++ b/blog/src/widgets/navigate/ui/SideBar.tsx
@@ -31,7 +31,7 @@ export const SideBar = () => {
 
       {/* 사이드바 컴포넌트 */}
       <aside
-        className={`absolute left-0 top-0 flex max-h-screen min-h-80 max-w-[80%] flex-col justify-between gap-4 overflow-y-auto bg-primary px-4 pb-1 pt-4 ${isOpen ? "" : "-translate-x-full"} z-50 rounded-r-lg shadow-md transition-transform duration-300`}
+        className={`absolute left-0 top-0 flex max-h-screen min-h-80 max-w-[80%] flex-col justify-between gap-4 overflow-y-auto bg-primary px-4 pb-1 pt-4 ${isOpen ? "" : "-translate-x-full"} z-50 rounded-r-lg transition-transform duration-300`}
         ref={sideBarRef}
       >
         <div>

--- a/blog/src/widgets/navigate/ui/SideBar.tsx
+++ b/blog/src/widgets/navigate/ui/SideBar.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { useGetArticleMetaListPerSeries } from "@/entities/article/model";
 import { AdminProfile } from "@/entities/user/ui";
 
-import { BackwardIcon, LibraryIcon } from "@/shared/config";
+import { BackwardIcon } from "@/shared/config";
 import { useSession } from "@/shared/model";
 
 export const SideBar = () => {
@@ -56,12 +56,11 @@ export const SideBar = () => {
                       key={index}
                       className="flex w-fit items-center gap-2 text-xl text-primary"
                     >
-                      <LibraryIcon />
                       {seriesName}
                     </p>
                     <ul className="flex flex-col gap-2 text-secondary">
                       {articleMetaList.map(({ title, id }) => (
-                        <li key={id} className="ml-4 list-disc">
+                        <li key={id} className="ml-8 list-disc">
                           <Link
                             href={`/article/${id}`}
                             className="hover:text-blue-500"


### PR DESCRIPTION
This pull request includes various changes to the blog application, focusing on CSS adjustments, font updates, and component improvements. Below is a summary of the most important changes:

### CSS Adjustments:

* [`blog/app/globals.css`](diffhunk://#diff-88be9522b5c244b56f4a48f7a29ccee3b813a35e83fd506632dfa55ac8c24543L202-L211): Removed the `.image` class and adjusted the `figcaption[data-rehype-pretty-code-title]` to use different content and font size. [[1]](diffhunk://#diff-88be9522b5c244b56f4a48f7a29ccee3b813a35e83fd506632dfa55ac8c24543L202-L211) [[2]](diffhunk://#diff-88be9522b5c244b56f4a48f7a29ccee3b813a35e83fd506632dfa55ac8c24543L300-R292)
* [`blog/app/globals.css`](diffhunk://#diff-88be9522b5c244b56f4a48f7a29ccee3b813a35e83fd506632dfa55ac8c24543L159): Updated the `p` element to remove border-radius and added a font-weight property. [[1]](diffhunk://#diff-88be9522b5c244b56f4a48f7a29ccee3b813a35e83fd506632dfa55ac8c24543L159) [[2]](diffhunk://#diff-88be9522b5c244b56f4a48f7a29ccee3b813a35e83fd506632dfa55ac8c24543R87)

### Font Updates:

* [`blog/app/layout.tsx`](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL4-R4): Changed the imported font from `IBM_Plex_Sans_KR` to `Gothic_A1` and updated the related class name. [[1]](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL4-R4) [[2]](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL16-R19) [[3]](diffhunk://#diff-172e57436ea1522632a8b7ec4f13e382c9f77008e435be76c8ff1f72b9304bccL31-R31)

### Component Improvements:

* [`blog/src/entities/series/ui/SeriesItem.tsx`](diffhunk://#diff-efd2329dcd92651556bd23a5925fc62e02b83c664ab913ca82f779a0e5a002faL15-R15): Modified the `SeriesItem` component to include a smoother transition effect and scaling on hover.
* [`blog/src/widgets/article/ui/ArticlePreviewCard.tsx`](diffhunk://#diff-983e02b156b8be0a96f51f473ecb08f99903f824a1235f6755c313fdd144ee52L27-R27): Enhanced the `ArticlePreviewCard` component with a transition effect and scaling on hover.
* [`blog/src/widgets/navigate/ui/SideBar.tsx`](diffhunk://#diff-2c4185263c58d807dc4151fda21e71e95b2712b5ef89e3794979045c19769bc2L9-R9): Removed the `LibraryIcon` and adjusted the margin for list items. [[1]](diffhunk://#diff-2c4185263c58d807dc4151fda21e71e95b2712b5ef89e3794979045c19769bc2L9-R9) [[2]](diffhunk://#diff-2c4185263c58d807dc4151fda21e71e95b2712b5ef89e3794979045c19769bc2L59-R63)

### Code Block Theme:

* [`blog/src/entities/article/lib/rehypeMarkdown.ts`](diffhunk://#diff-ecfea0075b8236f5344a3892d3441e3fd596dc3cdfe30416e8254246d52b31f7L31-R31): Updated the theme for code blocks from `tokyo-night` to `one-dark-pro`.