### PR TITLE
[Feat] 이전글, 다음글 가져오는 부분 클라이언트단으로 이동

### DIFF
--- a/blog/src/entities/article/model/articleQueryKey.ts
+++ b/blog/src/entities/article/model/articleQueryKey.ts
@@ -34,5 +34,7 @@ export const ARTICLE_QUERY_KEY = {
   infoPerSeries: () =>
     [...ARTICLE_QUERY_KEY.default("published"), "perSeries"] as const,
   metaListPerSeries: () =>
-    [...ARTICLE_QUERY_KEY.default("published"), "metaListPerSeries"] as const
+    [...ARTICLE_QUERY_KEY.default("published"), "metaListPerSeries"] as const,
+  graph: (articleId: number) =>
+    [...ARTICLE_QUERY_KEY.default("published"), "graph", articleId] as const
 };

--- a/blog/src/entities/article/model/getArticleById.ts
+++ b/blog/src/entities/article/model/getArticleById.ts
@@ -11,10 +11,6 @@ const ARTICLE_SELECT_FIELDS = `
   content, article_tags(tag_name)
 `;
 
-// 이전/다음 글 조회를 위한 필드
-const NEIGHBOR_ARTICLE_SELECT_FIELDS = `id, title`;
-
-// 기존 fetchArticleById 함수 유지
 const fetchArticleById = (
   articleId: number,
   status: "published" | "draft" | null
@@ -32,59 +28,6 @@ const fetchArticleById = (
   return finalQuery.single();
 };
 
-const fetchPreviousArticle = (
-  createdAt: string,
-  seriesName: string | null, // seriesName 파라미터 추가
-  status: "published" | "draft" | null
-) => {
-  const supabase = createBrowserSupabase();
-  let query = supabase
-    .from("articles")
-    .select(NEIGHBOR_ARTICLE_SELECT_FIELDS)
-    .lt("created_at", createdAt); // 현재 글보다 오래된 글
-
-  // seriesName이 null이 아닐 경우에만 series_name 필터링 추가
-  if (seriesName !== null) {
-    query = query.eq("series_name", seriesName);
-  } else {
-    // seriesName이 null이면, series_name이 null인 글만 찾도록 함
-    query = query.is("series_name", null);
-  }
-
-  query = query.order("created_at", { ascending: false }); // 최신 순으로 정렬
-
-  // status가 null이 아닐 경우에만 status 필터링 추가
-  const finalQuery = status !== null ? query.eq("status", status) : query;
-
-  return finalQuery.limit(1).maybeSingle(); // 하나만 가져오거나 null 반환
-};
-
-const fetchNextArticle = (
-  createdAt: string,
-  seriesName: string | null, // seriesName 파라미터 추가
-  status: "published" | "draft" | null
-) => {
-  const supabase = createBrowserSupabase();
-  let query = supabase
-    .from("articles")
-    .select(NEIGHBOR_ARTICLE_SELECT_FIELDS)
-    .gt("created_at", createdAt); // 현재 글보다 최신 글
-
-  // seriesName이 null이 아닐 경우에만 series_name 필터링 추가
-  if (seriesName !== null) {
-    query = query.eq("series_name", seriesName);
-  } else {
-    // seriesName이 null이면, series_name이 null인 글만 찾도록 함
-    query = query.is("series_name", null);
-  }
-
-  query = query.order("created_at", { ascending: true }); // 오래된 순으로 정렬
-
-  // status가 null이 아닐 경우에만 status 필터링 추가
-  const finalQuery = status !== null ? query.eq("status", status) : query;
-
-  return finalQuery.limit(1).maybeSingle(); // 하나만 가져오거나 null 반환
-};
 const transformArticleData = async <
   T extends {
     content: string;
@@ -121,28 +64,11 @@ export const getArticleById = async (
 
   const currentArticle = snakeToCamel(currentArticleData);
 
-  // 2. 이전 글과 다음 글 정보 병렬 조회
-  const [{ data: prevArticleData }, { data: nextArticleData }] =
-    await Promise.all([
-      fetchPreviousArticle(
-        currentArticle.createdAt,
-        currentArticle.seriesName,
-        status
-      ),
-      fetchNextArticle(
-        currentArticle.createdAt,
-        currentArticle.seriesName,
-        status
-      )
-    ]);
-
-  // 3. 현재 글 데이터 변환 (Markdown -> HTML 등)
+  // 2. 현재 글 데이터 변환 (Markdown -> HTML 등)
   const transformedCurrentArticle = await transformArticleData(currentArticle);
 
-  // 4. 최종 결과 조합
+  // 3. 최종 결과 조합
   return {
-    ...transformedCurrentArticle,
-    previousArticle: prevArticleData ? snakeToCamel(prevArticleData) : null,
-    nextArticle: nextArticleData ? snakeToCamel(nextArticleData) : null
+    ...transformedCurrentArticle
   };
 };

--- a/blog/src/entities/article/model/getArticleGraph.ts
+++ b/blog/src/entities/article/model/getArticleGraph.ts
@@ -1,0 +1,37 @@
+import { ARTICLE_QUERY_KEY } from "./articleQueryKey";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+import { createBrowserSupabase } from "@/shared/lib";
+
+const getArticleGraph = async (articleId: number, seriesName: string) => {
+  const supabase = createBrowserSupabase();
+
+  const { data, error } = await supabase
+    .from("articles")
+    .select("id, title")
+    .eq("series_name", seriesName)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  if (!data) {
+    return { prevArticleData: null, nextArticleData: null };
+  }
+
+  const currentIndex = data.findIndex((article) => article.id === articleId);
+
+  const prevArticleData = currentIndex > 0 ? data[currentIndex - 1] : null;
+  const nextArticleData =
+    currentIndex < data.length - 1 ? data[currentIndex + 1] : null;
+
+  return { prevArticleData, nextArticleData };
+};
+
+export const useGetArticleGraph = (articleId: number, seriesName: string) => {
+  return useSuspenseQuery({
+    queryKey: ARTICLE_QUERY_KEY.graph(articleId),
+    queryFn: () => getArticleGraph(articleId, seriesName)
+  });
+};

--- a/blog/src/entities/article/model/index.ts
+++ b/blog/src/entities/article/model/index.ts
@@ -10,3 +10,4 @@ export * from "./deleteArticle";
 export * from "./getNumberOfArticles";
 export * from "./utils";
 export * from "./getArticleMetaListPerSeries";
+export * from "./getArticleGraph";

--- a/blog/src/slots/[article]/ui/ArticleFooter.tsx
+++ b/blog/src/slots/[article]/ui/ArticleFooter.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import React from "react";
+import {
+  BiSolidLeftArrowCircle,
+  BiSolidRightArrowCircle
+} from "react-icons/bi";
+
+import { useGetArticleGraph } from "@/entities/article/model/getArticleGraph";
+
+interface ArticleFooterProps {
+  articleId: string;
+  seriesName: string;
+}
+
+export const ArticleFooter: React.FC<ArticleFooterProps> = ({
+  articleId,
+  seriesName
+}) => {
+  const {
+    data: { prevArticleData, nextArticleData }
+  } = useGetArticleGraph(Number(articleId), seriesName);
+
+  return (
+    <footer className="flex flex-col justify-between gap-4 text-lg sm:flex-row sm:justify-between">
+      {/* 하단 네비게이션 버튼 */}
+      <div className="flex-1">
+        {prevArticleData && (
+          <Link
+            href={`/article/${prevArticleData.id}`}
+            className="flex h-full flex-1 items-center justify-start gap-2 rounded-lg border border-purple-700 p-2 text-purple-700 hover:text-purple-500 dark:border-purple-300 dark:text-purple-300 hover:dark:text-purple-200"
+          >
+            <BiSolidLeftArrowCircle />
+            {prevArticleData.title}
+          </Link>
+        )}
+      </div>
+      <div className="flex flex-1">
+        {nextArticleData && (
+          <Link
+            href={`/article/${nextArticleData.id}`}
+            className="flex h-full flex-1 items-center justify-end gap-2 rounded-lg border border-purple-700 p-2 text-purple-700 hover:text-purple-500 dark:border-purple-300 dark:text-purple-300 hover:dark:text-purple-200"
+          >
+            {nextArticleData.title}
+            <BiSolidRightArrowCircle />
+          </Link>
+        )}
+      </div>
+    </footer>
+  );
+};

--- a/blog/src/slots/[article]/ui/ArticleSlot.tsx
+++ b/blog/src/slots/[article]/ui/ArticleSlot.tsx
@@ -1,12 +1,10 @@
 import { AdminArticleHeader } from "./AdminArticleHeader";
+import { ArticleFooter } from "./ArticleFooter";
 import { ProgressBar } from "./ProgressBar";
 import type { ArticlePageProps } from "./type";
 import Image from "next/image";
 import Link from "next/link";
-import {
-  BiSolidLeftArrowCircle,
-  BiSolidRightArrowCircle
-} from "react-icons/bi";
+import { Suspense } from "react";
 
 import { createNestedHeadings } from "@/features/article/lib/createNestedHeadings";
 import { ArticleSidebar } from "@/features/article/ui";
@@ -28,9 +26,7 @@ export const ArticleSlot: React.FC<ArticlePageProps> = async ({
     createdAt,
     seriesName,
     html,
-    headings,
-    previousArticle,
-    nextArticle
+    headings
   } = articleData;
 
   return (
@@ -89,31 +85,12 @@ export const ArticleSlot: React.FC<ArticlePageProps> = async ({
         {/* 본문 */}
         <article className="w-full pb-32 lg:flex-grow xl:max-w-[75%]">
           {html}
-          <footer className="flex flex-col justify-between gap-4 text-lg sm:flex-row sm:justify-between">
-            {/* 하단 네비게이션 버튼 */}
-            <div className="flex-1">
-              {previousArticle && (
-                <Link
-                  href={`/article/${previousArticle.id}`}
-                  className="flex h-full flex-1 items-center justify-start gap-2 rounded-lg border border-purple-700 p-2 text-purple-700 hover:text-purple-500 dark:border-purple-300 dark:text-purple-300 hover:dark:text-purple-200"
-                >
-                  <BiSolidLeftArrowCircle />
-                  {previousArticle.title}
-                </Link>
-              )}
-            </div>
-            <div className="flex flex-1">
-              {nextArticle && (
-                <Link
-                  href={`/article/${nextArticle.id}`}
-                  className="flex h-full flex-1 items-center justify-end gap-2 rounded-lg border border-purple-700 p-2 text-purple-700 hover:text-purple-500 dark:border-purple-300 dark:text-purple-300 hover:dark:text-purple-200"
-                >
-                  {nextArticle.title}
-                  <BiSolidRightArrowCircle />
-                </Link>
-              )}
-            </div>
-          </footer>
+          {/* 아티클 footer  */}
+          <Suspense
+            fallback={<div className="h-96 w-full animate-pulse rounded-lg" />}
+          >
+            <ArticleFooter articleId={articleId} seriesName={seriesName} />
+          </Suspense>
         </article>
         {/* 사이드바 */}
         <aside className="relative hidden text-gray-400 xl:block">

--- a/blog/src/slots/[article]/ui/type.ts
+++ b/blog/src/slots/[article]/ui/type.ts
@@ -11,14 +11,6 @@ export interface ArticlePageProps {
     content: string;
     headings: HeadingInfo[];
     html: string;
-    previousArticle: {
-      id: number;
-      title: string;
-    } | null;
-    nextArticle: {
-      id: number;
-      title: string;
-    } | null;
   };
   articleId: string;
 }


### PR DESCRIPTION
This pull request refactors the implementation of fetching and displaying previous and next articles in a series, replacing the old logic with a new `getArticleGraph` function and integrating it into the article footer. It also introduces a new `ArticleFooter` component and updates related files to use this new approach.

### Refactoring article navigation logic:
* Removed `fetchPreviousArticle` and `fetchNextArticle` functions from `blog/src/entities/article/model/getArticleById.ts`, along with their usage in `getArticleById`. The logic for fetching neighboring articles is now handled by the new `getArticleGraph` function. [[1]](diffhunk://#diff-7ce1f4117c96af21b3f8887c490d3123162381b54adb007bd4997684c22fccd0L35-L87) [[2]](diffhunk://#diff-7ce1f4117c96af21b3f8887c490d3123162381b54adb007bd4997684c22fccd0L124-R72)
* Added `getArticleGraph` and `useGetArticleGraph` in `blog/src/entities/article/model/getArticleGraph.ts` to fetch and cache the previous and next articles for a given article ID and series.
* Updated the `ARTICLE_QUERY_KEY` in `blog/src/entities/article/model/articleQueryKey.ts` to include a new `graph` key for querying article graphs.

### UI updates:
* Created a new `ArticleFooter` component in `blog/src/slots/[article]/ui/ArticleFooter.tsx` to display navigation links for the previous and next articles using `useGetArticleGraph`. ([blog/src/slots/[article]/ui/ArticleFooter.tsxR1-R52](diffhunk://#diff-00d78bfbcf766bbe98237dd0775f6cded2c282734746b30c35778b1cce455891R1-R52))
* Updated `ArticleSlot` in `blog/src/slots/[article]/ui/ArticleSlot.tsx` to replace the inline footer logic with the new `ArticleFooter` component, wrapped in a `Suspense` fallback. Removed the old `previousArticle` and `nextArticle` props. ([blog/src/slots/[article]/ui/ArticleSlot.tsxR2-R7](diffhunk://#diff-381082be1fb15f80f988e16501f2ecfd5f5446e8c8eff17042bf947d424a6e92R2-R7), [blog/src/slots/[article]/ui/ArticleSlot.tsxL31-R29](diffhunk://#diff-381082be1fb15f80f988e16501f2ecfd5f5446e8c8eff17042bf947d424a6e92L31-R29), [blog/src/slots/[article]/ui/ArticleSlot.tsxL92-R93](diffhunk://#diff-381082be1fb15f80f988e16501f2ecfd5f5446e8c8eff17042bf947d424a6e92L92-R93))

### Cleanup:
* Removed the `previousArticle` and `nextArticle` fields from the `ArticlePageProps` interface in `blog/src/slots/[article]/ui/type.ts`, as they are no longer needed. ([blog/src/slots/[article]/ui/type.tsL14-L21](diffhunk://#diff-07344b784379ea6b8f6fba256161017e3f03a69a376f94ecf7315e03571ea58fL14-L21))
* Exported the new `getArticleGraph` module in `blog/src/entities/article/model/index.ts`.

모두 서버액션 및 revalidatePath 를 이용해서 서버단에서 효율적으로 캐싱하려고 하였지만 문제를 발견했다.

현재 내 블로그의 CRUD 는 폭탄덩어리란것을 

하나의 게시글을 올릴 때 적어도 2개 이상의 테이블을 만지지만 이 테이블들은 모두 각자 처리된다.

N 개의 액션이 있다면 N 개의 에러가 발생 할 수 있으며 N 개 중 하나의 액션이라도 실패한다면 500에러가 발생하게 되지만 사실 N-1 개의 액션은 DB에 모두 적용이 된 상태이다.

이걸 해결하기 위해 트랜잭션을 이용해야 한다는데 추후 처리해야겠다.

트랜잭션을 이용하고 그 후에 게시글별로 그래프로 이어 이전글과 다음글을 표현하도록 하자 